### PR TITLE
Make dumper's available for sf2

### DIFF
--- a/DependencyInjection/Compiler/AddDumperPass.php
+++ b/DependencyInjection/Compiler/AddDumperPass.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the BazingaGeocoderBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Bazinga\Bundle\GeocoderBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ */
+class AddDumperPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('bazinga_geocoder.dumper_manager')) {
+            return;
+        }
+
+        $manager = $container->findDefinition('bazinga_geocoder.dumper_manager');
+
+        $dumpers = array();
+        foreach ($container->findTaggedServiceIds('geocoder.dumper') as $id => $attributes) {
+            if (!isset($attributes[0]['alias'])) {
+                throw new \RuntimeException(sprintf('No alias for service "%s" provided. Please set a alias!', $id));
+            }
+
+            $dumpers[$attributes[0]['alias']] = $container->getDefinition($id);
+        }
+
+        $manager->setArguments(array($dumpers));
+    }
+}

--- a/DumperManager.php
+++ b/DumperManager.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * This file is part of the BazingaGeocoderBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+
+namespace Bazinga\Bundle\GeocoderBundle;
+
+use Geocoder\Dumper\DumperInterface;
+
+/**
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ */
+class DumperManager
+{
+    /**
+     * @var array
+     */
+    private $dumpers;
+
+    /**
+     * Constructor
+     *
+     * @param array $dumpers
+     */
+    public function __construct(array $dumpers = array())
+    {
+        $this->dumpers = array();
+
+        foreach ($dumpers as $name => $dumper) {
+            $this->set($name, $dumper);
+        }
+    }
+
+    /**
+     * Get a dumper
+     *
+     * @param string $name The name of the dumper
+     *
+     * @return DumperInterface
+     *
+     * @throws \RuntimeException If no dumper was found
+     */
+    public function get($name)
+    {
+        if (!isset($this->dumpers[$name])) {
+            throw new \RuntimeException(sprintf('The dumper "%s" does not exist', $name));
+        }
+
+        return $this->dumpers[$name];
+    }
+
+    /**
+     * Sets a dumper
+     *
+     * @param string          $name   The name
+     * @param DumperInterface $dumper The dumper instance
+     */
+    public function set($name, DumperInterface $dumper)
+    {
+        $this->dumpers[$name] = $dumper;
+    }
+
+    /**
+     * Remove a dumper instance from the manager
+     *
+     * @param string $name The name of the dumper
+     *
+     * @throws \RuntimeException If no dumper was found
+     */
+    public function remove($name)
+    {
+        if (!isset($this->dumpers[$name])) {
+            throw new \RuntimeException(sprintf('The dumper "%s" does not exist', $name));
+        }
+
+        unset($this->dumpers[$name]);
+    }
+
+    /**
+     * Return true if $name exists, false otherwise.
+     *
+     * @param $name The name of the dumper
+     *
+     * @return bool
+     */
+    public function has($name)
+    {
+        return array_key_exists($name, $this->dumpers);
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -17,6 +17,13 @@
         <parameter key="bazinga_geocoder.geocoder.provider.geoip.class">Geocoder\Provider\GeoipProvider</parameter>
 
         <parameter key="bazinga_geocoder.event_listener.fake_request.class">Bazinga\Bundle\GeocoderBundle\EventListener\FakeRequestListener</parameter>
+
+        <parameter key="bazinga_geocoder.dumper_manager.class">Bazinga\Bundle\GeocoderBundle\DumperManager</parameter>
+        <parameter key="bazinga_geocoder.dumper.geojson.class">Geocoder\Dumper\GeoJsonDumper</parameter>
+        <parameter key="bazinga_geocoder.dumper.gpx.class">Geocoder\Dumper\GpxDumper</parameter>
+        <parameter key="bazinga_geocoder.dumper.kmp.class">Geocoder\Dumper\KmlDumper</parameter>
+        <parameter key="bazinga_geocoder.dumper.wkp.class">Geocoder\Dumper\WkpDumper</parameter>
+        <parameter key="bazinga_geocoder.dumper.wkt.class">Geocoder\Dumper\WktDumper</parameter>
     </parameters>
 
     <services>
@@ -24,6 +31,26 @@
 
         <!-- Adapters -->
         <service id="bazinga_geocoder.geocoder.adapter" class="%bazinga_geocoder.geocoder.adapter.class%" public="false" />
+
+        <!-- Dumpers -->
+        <service id="bazinga_geocoder.dumper_manager" class="%bazinga_geocoder.dumper_manager.class">
+            <argument type="collection" /><!-- Placeholder -->
+        </service>
+        <service id="bazinga_geocoder.dumper.geojson" class="%bazinga_geocoder.dumper.geojson.class%">
+            <tag name="geocoder.dumper" alias="geojson" />
+        </service>
+        <service id="bazinga_geocoder.dumper.gpx" class="%bazinga_geocoder.dumper.gpx.class%">
+            <tag name="geocoder.dumper" alias="gpx" />
+        </service>
+        <service id="bazinga_geocoder.dumper.kmp" class="%bazinga_geocoder.dumper.kmp.class%">
+            <tag name="geocoder.dumper" alias="kmp" />
+        </service>
+        <service id="bazinga_geocoder.dumper.wkp" class="%bazinga_geocoder.dumper.wkp.class%">
+            <tag name="geocoder.dumper" alias="wkp" />
+        </service>
+        <service id="bazinga_geocoder.dumper.wkt" class="%bazinga_geocoder.dumper.wkt%">
+            <tag name="geocoder.dumper" alias="wkt" />
+        </service>
 
         <!-- Listener -->
         <service id="bazinga_geocoder.event_listener.fake_request" class="%bazinga_geocoder.event_listener.fake_request.class%">

--- a/Tests/DependencyInjection/Compiler/AddDumperPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddDumperPassTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Bazinga\Bundle\GeocoderBundle\Tests\DependencyInjection\Compiler;
+
+use Bazinga\Bundle\GeocoderBundle\DependencyInjection\Compiler\AddDumperPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ */
+class AddDumperPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcess()
+    {
+        $builder = new ContainerBuilder;
+        $builder->setDefinition('bazinga_geocoder.dumper_manager', new Definition('Bazinga\Bundle\GeocoderBundle\DumperManager'));
+
+        $dumper = new Definition('Geocoder\Dumper\GeoJsonDumper');
+        $dumper->addTag('geocoder.dumper', array('alias' => 'geojson'));
+
+        $builder->setDefinition('bazinga_geocoder.dumper.geojson', $dumper);
+
+        $compiler = new AddDumperPass();
+        $compiler->process($builder);
+
+        $manager = $builder->get('bazinga_geocoder.dumper_manager');
+
+        $this->assertTrue($manager->has('geojson'));
+    }
+
+    public function testProcessWithoutManager()
+    {
+        $builder = new ContainerBuilder();
+        $compiler = new AddDumperPass;
+
+        $this->assertNull($compiler->process($builder));
+    }
+}

--- a/Tests/DumperManagerTest.php
+++ b/Tests/DumperManagerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Bazinga\Bundle\GeocoderBundle\Tests;
+
+use Bazinga\Bundle\GeocoderBundle\DumperManager;
+
+/**
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ */
+class DumperManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var DumperManager
+     */
+    private $manager;
+
+    protected function setup()
+    {
+        $this->manager = new DumperManager;
+    }
+
+    public function testSet()
+    {
+        $this->assertNull($this->manager->set('test', $this->getMock('Geocoder\\Dumper\\DumperInterface')));
+    }
+
+    public function testGet()
+    {
+        $dumper = $this->getMock('Geocoder\\Dumper\\DumperInterface');
+        $this->manager->set('test', $dumper);
+
+        $this->assertEquals($dumper, $this->manager->get('test'));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testGetNotExistDumper()
+    {
+        $this->manager->get('not-exist');
+    }
+
+    public function testHas()
+    {
+        $this->assertFalse($this->manager->has('test'));
+        $this->manager->set('test', $this->getMock('Geocoder\\Dumper\\DumperInterface'));
+        $this->assertTrue($this->manager->has('test'));
+    }
+
+    public function testRemove()
+    {
+        $this->manager->set('test', $this->getMock('Geocoder\\Dumper\\DumperInterface'));
+        $this->manager->remove('test');
+        $this->assertFalse($this->manager->has('test'));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testRemoveNotExistDumper()
+    {
+        $this->manager->remove('not-exist');
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+
+if (!@require_once __DIR__ . '/../vendor/autoload.php') {
+    die("You must set up the project dependencies, run the following commands:
+wget http://getcomposer.org/composer.phar
+php composer.phar install --dev
+");
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="Tests/bootstrap.php"
+        >
+    <testsuites>
+        <testsuite name="Geocoder for the Symfony Framework">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>.</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
Hey!

I've created a `DumperManager` that provide all dumpers. 
You can easily add more dumper's to the manager with DI - Tags.

e.g.:

``` xml
<service id="my_bundle.some_dumper" class="%my_bundle.some_dumper.class%">
    <tag name="geocoder.dumper" alias="my_dumper" />
</service>
```

The dumper is registerd as `bazinga_geocoder.dumper_manager`. 

Simple usage:

``` php
<?php
class GeocoderController extends Controller 
{
    // [...]

    public function dump($ipAddress)
    {
         $result = $this->container->get('bazinga_geocoder.geocoder')->geocode($ipAddress);
         $dumper = $this->container->get('bazinga_geocoder.dumper_manager')->get('geojson');
         return new JsonResponse($dumper->dump($result));
    }

    // [...]
}
```
