### PR TITLE
Fix for issue #22 (typo in dumper class name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ __Dumper__ component. The following dumper's are supported:
  * Geojson
  * GPX
  * KMP
- * WKP
+ * WKB
  * WKT
 
 Here is an example:

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -23,7 +23,7 @@
         <parameter key="bazinga_geocoder.dumper.geojson.class">Geocoder\Dumper\GeoJsonDumper</parameter>
         <parameter key="bazinga_geocoder.dumper.gpx.class">Geocoder\Dumper\GpxDumper</parameter>
         <parameter key="bazinga_geocoder.dumper.kmp.class">Geocoder\Dumper\KmlDumper</parameter>
-        <parameter key="bazinga_geocoder.dumper.wkp.class">Geocoder\Dumper\WkpDumper</parameter>
+        <parameter key="bazinga_geocoder.dumper.wkb.class">Geocoder\Dumper\WkbDumper</parameter>
         <parameter key="bazinga_geocoder.dumper.wkt.class">Geocoder\Dumper\WktDumper</parameter>
     </parameters>
 
@@ -46,8 +46,8 @@
         <service id="bazinga_geocoder.dumper.kmp" class="%bazinga_geocoder.dumper.kmp.class%">
             <tag name="geocoder.dumper" alias="kmp" />
         </service>
-        <service id="bazinga_geocoder.dumper.wkp" class="%bazinga_geocoder.dumper.wkp.class%">
-            <tag name="geocoder.dumper" alias="wkp" />
+        <service id="bazinga_geocoder.dumper.wkb" class="%bazinga_geocoder.dumper.wkb.class%">
+            <tag name="geocoder.dumper" alias="wkb" />
         </service>
         <service id="bazinga_geocoder.dumper.wkt" class="%bazinga_geocoder.dumper.wkt.class%">
             <tag name="geocoder.dumper" alias="wkt" />


### PR DESCRIPTION
This commit fixes issue #22.

Problem was a typo in dumper class name (WKP instead of WKB).
