### PR TITLE
Fix cacheProvider config

### DIFF
--- a/DependencyInjection/BazingaGeocoderExtension.php
+++ b/DependencyInjection/BazingaGeocoderExtension.php
@@ -150,10 +150,19 @@ class BazingaGeocoderExtension extends Extension
         if (isset($config['providers']['cache'])) {
             $params = $config['providers']['cache'];
 
-            $cache = new Reference($params['adapter']);
-            $fallback = new Reference('bazinga_geocoder.provider.'.$params['provider']);
+            $provider = new Definition(
+                '%bazinga_geocoder.geocoder.provider.cache.class%',
+                array(
+                    new Reference($params['adapter']),
+                    new Reference('bazinga_geocoder.provider.'.$params['provider'])
+                )
+            );
 
-            $this->addProvider('cache', array($cache, $fallback));
+            $provider
+                ->setPublic(false)
+                ->addTag('bazinga_geocoder.provider');
+
+            $this->container->setDefinition('bazinga_geocoder.provider.cache', $provider);
         }
     }
 


### PR DESCRIPTION
I don't know if I'm alone but currently we can't use the CacheProvider.

Now, if you have a config like this:

``` yaml
bazinga_geocoder:
    providers:
        google_maps:
            locale: fr
        cache:
            provider: google_maps
            adapter: my.doctrine.cache
            lifetime: 86400
            locale: fr
```

you can _really_ use the cache provider:

``` php

$geocoder = $this->container->get('bazinga_geocoder.geocoder');
$result = $geocoder->using('cache')->geocode('My street 124, New city');
```
