### PR TITLE
Fixed tag definition for fake_ip event

### DIFF
--- a/DependencyInjection/BazingaGeocoderExtension.php
+++ b/DependencyInjection/BazingaGeocoderExtension.php
@@ -42,8 +42,7 @@ class BazingaGeocoderExtension extends Extension
 
             $tag = current($definition->getTag('kernel.event_listener'));
             $tag['priority'] = $config['fake_ip']['priority'];
-            $tags = array();
-            $tags[] = array('kernel.event_listener' => $tag);
+            $tags = array('kernel.event_listener' => array($tag));
             $definition->setTags($tags);
         } else {
             $container->removeDefinition('bazinga_geocoder.event_listener.fake_request');


### PR DESCRIPTION
Fake ip listener is not triggered, due invalid tag rewrite.
Check [tags] dumb below, event name and index are swapped.

Expected definition dump for 'bazinga_geocoder.event_listener.fake_request' service id.

```
object(Symfony\Component\DependencyInjection\Definition)[688]
  private 'class' => string '%bazinga_geocoder.event_listener.fake_request.class%' (length=52)
  . . .
  private 'tags' => 
    array (size=1)
      'kernel.event_listener' => 
        array (size=1)
          0 => 
            array (size=2)
              'event' => string 'kernel.request' (length=14)
              'method' => string 'onKernelRequest' (length=15)
              'priority' => int 128
  . . .
  protected 'arguments' => 
    array (size=1)
      0 => string '123.345.643.133' (length=15)
```

Actual definition dump for 'bazinga_geocoder.event_listener.fake_request' service id.

```
object(Symfony\Component\DependencyInjection\Definition)[688]
  private 'class' => string '%bazinga_geocoder.event_listener.fake_request.class%' (length=52)
  . . .
  private 'tags' => 
    array (size=1)
      0 => 
        array (size=1)
          'kernel.event_listener' => 
            array (size=3)
              'event' => string 'kernel.request' (length=14)
              'method' => string 'onKernelRequest' (length=15)
              'priority' => int 128
  . . .
  protected 'arguments' => 
    array (size=1)
      0 => string '123.345.643.133' (length=15)
```
