### PR TITLE
Initialize $data in case there are no results

### DIFF
--- a/Logger/GeocoderLogger.php
+++ b/Logger/GeocoderLogger.php
@@ -48,6 +48,7 @@ class GeocoderLogger
         }
 
         if ($results instanceof \SplObjectStorage) {
+            $data = array();
             foreach ($results as $result) {
                 $data[] = $result->toArray();
             }


### PR DESCRIPTION
When no results, $data is uninitialized which causes an error when trying to access it.
