### PR TITLE
CacheProvider: better hashing function and namespace

### DIFF
--- a/Provider/CacheProvider.php
+++ b/Provider/CacheProvider.php
@@ -65,7 +65,7 @@ class CacheProvider implements ProviderInterface
      */
     public function getGeocodedData($address)
     {
-        $key = crc32($this->locale.$address);
+        $key = 'geocoder_' . sha1($this->locale . $address);
 
         if (false !== $data = $this->cache->fetch($key)) {
             return unserialize($data);
@@ -82,7 +82,7 @@ class CacheProvider implements ProviderInterface
      */
     public function getReversedData(array $coordinates)
     {
-        $key = crc32(serialize($this->locale . json_encode($coordinates)));
+        $key = 'geocoder_' . sha1($this->locale . json_encode($coordinates));
 
         if (false !== $data = $this->cache->fetch($key)) {
             return unserialize($data);

--- a/Tests/Provider/CacheProviderTest.php
+++ b/Tests/Provider/CacheProviderTest.php
@@ -14,6 +14,7 @@ class CacheProviderTest extends \PHPUnit_Framework_TestCase
     {
         $address = 'Paris, France';
         $coordinates = array('lat' => 48.857049,'lng' => 2.35223);
+        $cacheKey = 'geocoder_' . sha1($address);
 
         $delegate = $this->getMock('Geocoder\\Provider\\ProviderInterface');
         $delegate->expects($this->once())
@@ -24,12 +25,12 @@ class CacheProviderTest extends \PHPUnit_Framework_TestCase
         $cache = $this->getMock('Doctrine\\Common\\Cache\\Cache');
         $cache->expects($this->once())
             ->method('fetch')
-            ->with(crc32($address))
+            ->with($cacheKey)
             ->will($this->returnValue(false));
 
         $cache->expects($this->once())
             ->method('save')
-            ->with(crc32($address), serialize($coordinates), 0);
+            ->with($cacheKey, serialize($coordinates), 0);
 
         $provider = new CacheProvider($cache, $delegate);
         $this->assertEquals($coordinates, $provider->getGeocodedData($address));
@@ -39,6 +40,7 @@ class CacheProviderTest extends \PHPUnit_Framework_TestCase
     {
         $address = 'Paris, France';
         $coordinates = array('lat' => 48.857049,'lng' => 2.35223);
+        $cacheKey = 'geocoder_' . sha1($address);
 
         $delegate = $this->getMock('Geocoder\\Provider\\ProviderInterface');
         $delegate->expects($this->once())
@@ -51,7 +53,7 @@ class CacheProviderTest extends \PHPUnit_Framework_TestCase
         $provider->getGeocodedData($address);
         $provider->getGeocodedData($address);
 
-        $this->assertTrue($cache->contains(crc32($address)));
+        $this->assertTrue($cache->contains($cacheKey));
     }
 
     public function testGetReversedData()


### PR DESCRIPTION
Hi William,
    I've improved the cache key generation for the `CacheProvider`, to reduce cache pollution and reduce collision probability.

The main problem with the current implementation is that cache key are stored without any sort of namespaces. This is a problem, since a simple `crc32($ip)` for example has high probability of collision especially with old codebase. Also this may introduce security issue (just speculating, didn't tested actually): what if a malicious user types `"anotherpkg_hashkey"` as a string in a geocoding field? A simple namespace solves this issue. Note that this isn't a BC, since Cache interface documentation explicitly say that keys are strings (even if in the current implementation are numeric strings).

I've changed CRC32 to SHA1, which are comparable in terms of performance, but SHA1 is better suited for hashing (some source: https://web.archive.org/web/20120722074858/http://bretm.home.comcast.net/~bretm/hash/8.html ). 

To further improve the cache hit ratio when reverse geocoding, the key can be generated with:

``` php
$key = 'geocoder_' . sha1(sprintf("%s%.6F%.6F", $this->locale, $coordinates[0], $coordinates[1]);
```

but this may require some sanity check for the $coordinates array. What do you think?
