### PR TITLE
External services on chain providers & Perform no deep merging on providers.

### DIFF
--- a/DependencyInjection/BazingaGeocoderExtension.php
+++ b/DependencyInjection/BazingaGeocoderExtension.php
@@ -236,6 +236,8 @@ class BazingaGeocoderExtension extends Extension
                         $chainProvider->addMethodCall('addProvider', array(
                             $this->container->getDefinition('bazinga_geocoder.provider.'.$name)
                         ));
+                    } else {
+                        $chainProvider->addMethodCall('addProvider', array(new Reference($name)));
                     }
                 }
             }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -172,6 +172,7 @@ class Configuration implements ConfigurationInterface
                     ->fixXmlConfig('provider')
                     ->children()
                         ->arrayNode('providers')
+                            ->performNoDeepMerging()
                             ->prototype('scalar')->end()
                         ->end()
                     ->end()


### PR DESCRIPTION
### External services on chain providers

Before this PR, only providers with prefix “bazinga_geocoder.provider.“ are supported. Even if you prefix your service by it, you'll have to register your bundle before BazingaGeocoderBundle (see [here](https://github.com/geocoder-php/BazingaGeocoderBundle/blob/master/DependencyInjection/BazingaGeocoderExtension.php#L235).

```
bazinga_geocoder:
    providers:
        google_maps: ~
        chain:
            providers: [app.x.provider.foo, google_maps]
```
### Perform no deep merging on providers.

Providers are merged through configurations, it could be problematic, my use case:

```
# config.yml
bazinga_geocoder:
    providers:
        google_maps: ~
        chain:
            providers: [google_maps]
```

```
# config_test.yml
bazinga_geocoder:
    providers:
        chain:
            providers: [xxx.provider.stub]
```

Before this PR, on `test` environment: `chain` providers will have  `[google_maps, xxx.provider.stub]` providers. 
After this PR, providers are not deep merged.
