### PR TITLE
Add default_provider parameter

### DIFF
--- a/DependencyInjection/BazingaGeocoderExtension.php
+++ b/DependencyInjection/BazingaGeocoderExtension.php
@@ -36,6 +36,10 @@ class BazingaGeocoderExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
+        if ($config['default_provider']) {
+            $container->setParameter('bazinga_geocoder.default_provider', $config['default_provider']);
+        }
+
         if (!empty($config['fake_ip']) && true === $config['fake_ip']['enabled']) {
             $definition = $container->getDefinition('bazinga_geocoder.event_listener.fake_request');
             $definition->replaceArgument(0, $config['fake_ip']['ip']);

--- a/DependencyInjection/Compiler/AddProvidersPass.php
+++ b/DependencyInjection/Compiler/AddProvidersPass.php
@@ -41,9 +41,14 @@ class AddProvidersPass implements CompilerPassInterface
             $array[] = new Reference($providerId);
         }
 
-        $container
-            ->getDefinition('bazinga_geocoder.geocoder')
-            ->addMethodCall('registerProviders', array($array))
-        ;
+        $geocoderDefinition =$container->getDefinition('bazinga_geocoder.geocoder');
+        $geocoderDefinition->addMethodCall('registerProviders', array($array));
+
+        if ($container->hasParameter('bazinga_geocoder.default_provider')) {
+            $geocoderDefinition->addMethodCall(
+                'using',
+                array($container->getParameter('bazinga_geocoder.default_provider'))
+            );
+        }
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+            ->scalarNode('default_provider')->defaultNull()->end()
             ->arrayNode('fake_ip')
                 ->beforeNormalization()
                 ->ifString()

--- a/Tests/DependencyInjection/BazingaGeocoderExtensionTest.php
+++ b/Tests/DependencyInjection/BazingaGeocoderExtensionTest.php
@@ -18,6 +18,8 @@ class BazingaGeocoderExtensionTest extends \PHPUnit_Framework_TestCase
     public function testLoad()
     {
         $configs   = Yaml::parse(file_get_contents(__DIR__.'/Fixtures/config.yml'));
+        unset($configs['bazinga_geocoder']['default_provider']);
+
         $container = new ContainerBuilder();
         $extension = new BazingaGeocoderExtension();
 
@@ -46,6 +48,8 @@ class BazingaGeocoderExtensionTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($dumperManager->has($name));
         }
 
+        $this->assertFalse($container->hasParameter('bazinga_geocoder.default_provider'));
+
         $geocoder  = $container->get('bazinga_geocoder.geocoder');
         $providers = $geocoder->getProviders();
         foreach (array(
@@ -73,6 +77,24 @@ class BazingaGeocoderExtensionTest extends \PHPUnit_Framework_TestCase
         ) as $name => $class) {
             $this->assertInstanceOf($class, $providers[$name], sprintf('-> Assert that %s is instance of %s', $name, $class));
         }
+    }
+
+    public function testDefaultProvider()
+    {
+        $configs   = Yaml::parse(file_get_contents(__DIR__.'/Fixtures/config.yml'));
+        $container = new ContainerBuilder();
+        $extension = new BazingaGeocoderExtension();
+
+        $container->setParameter('fixtures_dir', __DIR__ . '/Fixtures');
+
+        $container->set('doctrine.apc.cache', new ArrayCache());
+
+        $container->addCompilerPass(new AddProvidersPass());
+        $extension->load($configs, $container);
+
+        $container->compile();
+
+        $this->assertEquals('bing_maps', $container->getParameter('bazinga_geocoder.default_provider'));
     }
 
     public function testLoadingFakeIpOldWay()

--- a/Tests/DependencyInjection/Fixtures/config.yml
+++ b/Tests/DependencyInjection/Fixtures/config.yml
@@ -1,4 +1,5 @@
 bazinga_geocoder:
+    default_provider: bing_maps
     fake_ip:
         ip: 33.33.33.11
         priority: 128


### PR DESCRIPTION
Adds the posibility to change the default provider.
Currently is the default provider the first provider in `config.yml`.

Closes #64
