### PR TITLE
Locale aware cache provider

### DIFF
--- a/Provider/Cache.php
+++ b/Provider/Cache.php
@@ -11,13 +11,17 @@ namespace Bazinga\Bundle\GeocoderBundle\Provider;
 
 use Doctrine\Common\Cache\Cache as DoctrineCache;
 use Geocoder\Provider\AbstractProvider;
+use Geocoder\Provider\LocaleAwareProvider;
+use Geocoder\Provider\LocaleTrait;
 use Geocoder\Provider\Provider;
 
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  */
-class Cache extends AbstractProvider implements Provider
+class Cache extends AbstractProvider implements LocaleAwareProvider
 {
+    use LocaleTrait;
+
     /**
      * @var Cache
      */


### PR DESCRIPTION
In order to cache results based on locale Cache provider has to implement LocaleAwareProvider interface. This fixes problem when geocode result is cached in one language and then same  address requested in another language.