### PR TITLE
fix fakeIP extension id after removing it from services.xml

### DIFF
--- a/DependencyInjection/BazingaGeocoderExtension.php
+++ b/DependencyInjection/BazingaGeocoderExtension.php
@@ -10,6 +10,7 @@
 
 namespace Bazinga\GeocoderBundle\DependencyInjection;
 
+use Bazinga\GeocoderBundle\EventListener\FakeRequestListener;
 use Bazinga\GeocoderBundle\ProviderFactory\ProviderFactoryInterface;
 use Geocoder\Provider\Cache\ProviderCache;
 use Geocoder\Provider\Provider;
@@ -40,10 +41,10 @@ class BazingaGeocoderExtension extends Extension
         $this->loadProviders($container, $config);
 
         if ($config['fake_ip']['enabled']) {
-            $definition = $container->getDefinition('bazinga_geocoder.event_listener.fake_request');
+            $definition = $container->getDefinition(FakeRequestListener::class);
             $definition->replaceArgument(0, $config['fake_ip']['ip']);
         } else {
-            $container->removeDefinition('bazinga_geocoder.event_listener.fake_request');
+            $container->removeDefinition(FakeRequestListener::class);
         }
     }
 


### PR DESCRIPTION
@Nyholm after moving parameters from xml to yml you removed service IDs as well.
Now it causes a crash when trying to use fakeIP.

It will be good to merge it soon to prevent those crashes. Also, probably when @willdurand will merge https://github.com/geocoder-php/BazingaGeocoderBundle/pull/150 the issue will stop occurring, as you created new classes there.