### PR TITLE
Fix deprecated Symfony 3.4 Data Collector without reset method

### DIFF
--- a/DataCollector/GeocoderDataCollector.php
+++ b/DataCollector/GeocoderDataCollector.php
@@ -36,6 +36,16 @@ class GeocoderDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
+    public function reset()
+    {
+        $this->instances = [];
+        $this->data['queries'] = [];
+        $this->data['providers'] = [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         if (!empty($this->data['queries'])) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

The data collector implementing the  "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface" interface without the "reset()" method is deprecated since version 3.4 and will be unsupported in 4.0.