### PR TITLE
Fix Documentation for Doctrine Support

### DIFF
--- a/Resources/doc/doctrine.md
+++ b/Resources/doc/doctrine.md
@@ -8,10 +8,10 @@ wanted.
 
 ``` php
 
-use Bazinga\GeocoderBundle\Mapping\Annotation as Geocoder;
+use Bazinga\GeocoderBundle\Mapping\Annotations as Geocoder;
 
 /**
- * @Geocoder\Geocodable
+ * @Geocoder\Geocodeable
  */
 class User
 {


### PR DESCRIPTION
- [x] Fixed typos where the path to annotation was wrong.
      Changed Annotation to Annotations.
- [x] Fixed typos where the name of annotation Geocodeable was wrong.
      Changed Geocodable to Geocodeable.