### PR TITLE
Add query Locale to profiler

### DIFF
--- a/Resources/views/Collector/geocoder.html.twig
+++ b/Resources/views/Collector/geocoder.html.twig
@@ -20,7 +20,6 @@
                     <tr>
                         <th>Provider</th>
                         <th>Query</th>
-                        <th>Locale</th>
                         <th>Time</th>
                     </tr>
                     </thead>
@@ -29,7 +28,6 @@
                         <tr>
                             <td>{{ query.providerName }}</td>
                             <td>{{ query.queryString }}</td>
-                            <td>{{ query.query.locale is not null ? query.query.locale : 'null' }}</td>
                             <td>{{ query.duration == 0 ? 'n/a' : query.duration|number_format ~ ' ms'}}</td>
                         </tr>
                     {% endfor %}

--- a/Resources/views/Collector/geocoder.html.twig
+++ b/Resources/views/Collector/geocoder.html.twig
@@ -20,6 +20,7 @@
                     <tr>
                         <th>Provider</th>
                         <th>Query</th>
+                        <th>Locale</th>
                         <th>Time</th>
                     </tr>
                     </thead>
@@ -28,6 +29,7 @@
                         <tr>
                             <td>{{ query.providerName }}</td>
                             <td>{{ query.queryString }}</td>
+                            <td>{{ query.query.locale is not null ? query.query.locale : 'null' }}</td>
                             <td>{{ query.duration == 0 ? 'n/a' : query.duration|number_format ~ ' ms'}}</td>
                         </tr>
                     {% endfor %}
@@ -73,6 +75,7 @@
                     <tr>
                         <th style="min-width: 2rem;"></th>
                         <th style="width: 40%">Query</th>
+                        <th style="min-width: 3rem;">Locale</th>
                         <th style="width: 60%">Result</th>
                         <th style="min-width: 4rem;">Duration</th>
                     </tr>
@@ -86,6 +89,11 @@
                         <td class="font-normal">
                             <span class="dump-inline">
                                 {{ query.queryString }}
+                            </span>
+                        </td>
+                        <td class="font-normal">
+                            <span class="dump-inline">
+                                {{ query.query.locale is not null ? query.query.locale : 'null' }}
                             </span>
                         </td>
                         <td class="font-normal">


### PR DESCRIPTION
I'm working with queries on differentes locales and I was thinking it could be interesting to get the locale for each query in the profiler

![capture du 2018-01-15 11-11-32](https://user-images.githubusercontent.com/2025537/34938771-ce74d31c-f9e9-11e7-8f7f-e6a56f20430e.png)

![capture du 2018-01-15 11-11-33_1](https://user-images.githubusercontent.com/2025537/34938765-cc409f68-f9e9-11e7-9ab8-d7bda781c542.png)
