### PR TITLE
Add required userAgent

### DIFF
--- a/ProviderFactory/NominatimFactory.php
+++ b/ProviderFactory/NominatimFactory.php
@@ -27,7 +27,7 @@ final class NominatimFactory extends AbstractFactory
     {
         $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
 
-        return new Nominatim($httplug, $config['root_url']);
+        return new Nominatim($httplug, $config['root_url'], $config['user_agent']);
     }
 
     protected static function configureOptionResolver(OptionsResolver $resolver)
@@ -35,9 +35,11 @@ final class NominatimFactory extends AbstractFactory
         $resolver->setDefaults([
             'httplug_client' => null,
             'root_url' => 'https://nominatim.openstreetmap.org',
+            'user_agent' => null,
         ]);
 
         $resolver->setAllowedTypes('httplug_client', ['object', 'null']);
         $resolver->setAllowedTypes('root_url', ['string']);
+        $resolver->setAllowedTypes('user_agent', ['string']);
     }
 }

--- a/Tests/Functional/config/provider/nominatim.yml
+++ b/Tests/Functional/config/provider/nominatim.yml
@@ -9,4 +9,4 @@ bazinga_geocoder:
       factory: Bazinga\GeocoderBundle\ProviderFactory\NominatimFactory
       options:
         root_url: 'https://nominatim.openstreetmap.org'
-
+        user_agent: 'geocoder-php test_suite'


### PR DESCRIPTION
The requirements of Nominatim state that a User-Agent must be submitted (https://operations.osmfoundation.org/policies/nominatim/). It looks like this was already implemented in the provider but not in the config (`ProviderFactory`). So `Geocoder\Provider\Nominatim` does now require a userAgent as third parameter.

Solves Issue: #195 