### PR TITLE
cache_lifetime can be null to let the underlying cache handle the lifetime

### DIFF
--- a/DependencyInjection/BazingaGeocoderExtension.php
+++ b/DependencyInjection/BazingaGeocoderExtension.php
@@ -112,6 +112,11 @@ class BazingaGeocoderExtension extends Extension
         }
 
         if (isset($config['cache']) || isset($config['cache_lifetime']) || isset($config['cache_precision'])) {
+            $cacheLifetime = isset($config['cache_lifetime']) ? $config['cache_lifetime'] : null;
+            if (null !== $cacheLifetime) {
+                $cacheLifetime = (int) $cacheLifetime;
+            }
+
             if (null === $cacheServiceId = $config['cache']) {
                 if (!$container->has('app.cache')) {
                     throw new \LogicException('You need to specify a service for cache.');
@@ -121,7 +126,7 @@ class BazingaGeocoderExtension extends Extension
             $plugins[] = $providerServiceId.'.cache';
             $container->register($providerServiceId.'.cache', CachePlugin::class)
                 ->setPublic(false)
-                ->setArguments([new Reference($cacheServiceId), (int) $config['cache_lifetime'], $config['cache_precision']]);
+                ->setArguments([new Reference($cacheServiceId), $cacheLifetime, $config['cache_precision']]);
         }
 
         if (isset($config['limit'])) {

--- a/Tests/Functional/BundleInitializationTest.php
+++ b/Tests/Functional/BundleInitializationTest.php
@@ -83,6 +83,30 @@ class BundleInitializationTest extends BaseBundleTestCase
         $this->assertInstanceOf(CachePlugin::class, $plugins[0]);
     }
 
+    /**
+     * @test
+     */
+    public function cache_lifetime_can_be_null_in_order_to_let_this_detail_handle_the_cache_service()
+    {
+        $kernel = $this->createKernel();
+        $kernel->addConfigFile(__DIR__.'/config/cache_without_lifetime.yml');
+        $this->bootKernel();
+        $container = $this->getContainer();
+
+        self::assertTrue($container->has('bazinga_geocoder.provider.acme'));
+        /** @var PluginProvider $service */
+        $service = $container->get('bazinga_geocoder.provider.acme');
+        self::assertInstanceOf(PluginProvider::class, $service);
+        $plugins = NSA::getProperty($service, 'plugins');
+        self::assertCount(1, $plugins);
+
+        $cachePlugin = array_shift($plugins);
+        self::assertInstanceOf(CachePlugin::class, $cachePlugin);
+
+        $cacheLifeTime = NSA::getProperty($cachePlugin, 'lifetime');
+        self::assertNull($cacheLifeTime);
+    }
+
     public function testBundleWithPluginsYml()
     {
         $kernel = $this->createKernel();

--- a/Tests/Functional/config/cache_without_lifetime.yml
+++ b/Tests/Functional/config/cache_without_lifetime.yml
@@ -1,0 +1,13 @@
+
+bazinga_geocoder:
+  profiling:
+    enabled: false
+  providers:
+    acme:
+      factory: Bazinga\GeocoderBundle\ProviderFactory\GoogleMapsFactory
+      cache_precision: 4
+      cache: acme.cache
+
+services:
+  acme.cache:
+    class: Bazinga\GeocoderBundle\Tests\Functional\Helper\CacheHelper


### PR DESCRIPTION
The CachePlugin was always able to have a lifetime = null, so this should also be used. I'm not completely sure, whether this is a bug, which should be fixed in other branches, or whether it is a new feature.

Use-Case is simple as that: I want to configure my cache completely independent of this bundle and only let the bundle know the service id.