### PR TITLE
Fix another SF 4.2 deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,6 +38,11 @@ class Configuration implements ConfigurationInterface
         $this->debug = (bool) $debug;
     }
     
+    /**
+     * Proxy to get root node for Symfony < 4.2
+     * @param TreeBuilder $treeBuilder
+     * @param string $name
+     */
     protected function getRootNode(TreeBuilder $treeBuilder, string $name)
     {
         if (\method_exists($treeBuilder, 'getRootNode')) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,6 +37,15 @@ class Configuration implements ConfigurationInterface
     {
         $this->debug = (bool) $debug;
     }
+    
+    protected function getRootNode(TreeBuilder $treeBuilder, string $name)
+    {
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+             return $treeBuilder->getRootNode();
+         } else {
+             return $treeBuilder->root($name);
+         }
+    }
 
     /**
      * Generates the configuration tree builder.
@@ -47,7 +56,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('bazinga_geocoder');
 
-        $treeBuilder->getRootNode()
+        $this->getRootNode($treeBuilder, 'bazinga_geocoder')
             ->children()
             ->append($this->getProvidersNode())
             ->arrayNode('profiling')
@@ -86,7 +95,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('providers');
 
-        return $treeBuilder->getRootNode()
+        return $this->getRootNode($treeBuilder, 'providers')
             ->requiresAtLeastOneElement()
             ->useAttributeAsKey('name')
             ->prototype('array')
@@ -119,7 +128,7 @@ class Configuration implements ConfigurationInterface
     private function createClientPluginNode()
     {
         $builder = new TreeBuilder('plugins');
-        $node = $builder->getRootNode();
+        $node = $this->getRootNode($builder, 'plugins');
 
         /** @var ArrayNodeDefinition $pluginList */
         $pluginList = $node

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,11 +37,11 @@ class Configuration implements ConfigurationInterface
     {
         $this->debug = (bool) $debug;
     }
-    
+
     /**
      * Proxy to get root node for Symfony < 4.2.
-     * @param TreeBuilder   $treeBuilder
-     * @param string        $name
+     * @param TreeBuilder $treeBuilder
+     * @param string      $name
      * @return NodeDefinition
      */
     protected function getRootNode(TreeBuilder $treeBuilder, string $name)

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -39,17 +39,18 @@ class Configuration implements ConfigurationInterface
     }
     
     /**
-     * Proxy to get root node for Symfony < 4.2
-     * @param TreeBuilder $treeBuilder
-     * @param string $name
+     * Proxy to get root node for Symfony < 4.2.
+     * @param TreeBuilder   $treeBuilder
+     * @param string        $name
+     * @return NodeDefinition
      */
     protected function getRootNode(TreeBuilder $treeBuilder, string $name)
     {
         if (\method_exists($treeBuilder, 'getRootNode')) {
-             return $treeBuilder->getRootNode();
-         } else {
-             return $treeBuilder->root($name);
-         }
+            return $treeBuilder->getRootNode();
+        } else {
+            return $treeBuilder->root($name);
+        }
     }
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,8 +40,10 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Proxy to get root node for Symfony < 4.2.
+     *
      * @param TreeBuilder $treeBuilder
      * @param string      $name
+     *
      * @return NodeDefinition
      */
     protected function getRootNode(TreeBuilder $treeBuilder, string $name)

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -45,10 +45,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('bazinga_geocoder');
+        $treeBuilder = new TreeBuilder('bazinga_geocoder');
 
-        $rootNode
+        $treeBuilder->getRootNode()
             ->children()
             ->append($this->getProvidersNode())
             ->arrayNode('profiling')
@@ -85,10 +84,9 @@ class Configuration implements ConfigurationInterface
      */
     private function getProvidersNode()
     {
-        $treeBuilder = new TreeBuilder();
-        $node = $treeBuilder->root('providers');
+        $treeBuilder = new TreeBuilder('providers');
 
-        $node
+        return $treeBuilder->getRootNode()
             ->requiresAtLeastOneElement()
             ->useAttributeAsKey('name')
             ->prototype('array')
@@ -111,8 +109,6 @@ class Configuration implements ConfigurationInterface
                     ->append($this->createClientPluginNode())
                 ->end()
             ->end();
-
-        return $node;
     }
 
     /**
@@ -122,8 +118,8 @@ class Configuration implements ConfigurationInterface
      */
     private function createClientPluginNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('plugins');
+        $builder = new TreeBuilder('plugins');
+        $node = $builder->getRootNode();
 
         /** @var ArrayNodeDefinition $pluginList */
         $pluginList = $node


### PR DESCRIPTION
> A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.
