### PR TITLE
Completed Doctrine documentation

### DIFF
--- a/Resources/doc/doctrine.md
+++ b/Resources/doc/doctrine.md
@@ -6,6 +6,8 @@ Wouldn't it be great if you could automatically save the coordinates of a users
 address every time it is updated? Wait not more here is the feature you been always
 wanted.
 
+First of all, update your entity:
+
 ```php
 
 use Bazinga\GeocoderBundle\Mapping\Annotations as Geocoder;
@@ -30,7 +32,29 @@ class User
      */
     private $longitude;
 }
+```
 
+Secondly, register the Doctrine event listener and its dependencies in your `services.yaml` file. 
+You have to indicate which provider to use to reverse geocode the address. Here we use `acme` provider we declared in bazinga_geocoder configuration earlier.
+
+```yaml
+    Bazinga\GeocoderBundle\Mapping\Driver\AnnotationDriver:
+        class: Bazinga\GeocoderBundle\Mapping\Driver\AnnotationDriver
+        arguments:
+            - '@annotations.reader'
+
+    Bazinga\GeocoderBundle\Doctrine\ORM\GeocoderListener:
+        class: Bazinga\GeocoderBundle\Doctrine\ORM\GeocoderListener
+        arguments:
+            - '@bazinga_geocoder.provider.acme'
+            - '@Bazinga\GeocoderBundle\Mapping\Driver\AnnotationDriver'
+        tags:
+            - doctrine.event_subscriber
+```
+
+It is done!  
+Now you can use it:
+```php
 $user = new User();
 $user->setAddress('Brandenburger Tor, Pariser Platz, Berlin');
 


### PR DESCRIPTION
Hello,

Doctrine documentation is missing a required step about registering the Doctrine event listener. It appears not to be declared anywhere otherwise.