### PR TITLE
Some Fixes for Doctrine Annotations

### DIFF
--- a/Doctrine/ORM/GeocoderListener.php
+++ b/Doctrine/ORM/GeocoderListener.php
@@ -95,7 +95,7 @@ class GeocoderListener implements EventSubscriber
                     $metadata->latitudeProperty->setValue($entity, $result->getCoordinates()->getLatitude());
                     $metadata->longitudeProperty->setValue($entity, $result->getCoordinates()->getLongitude());
                 }
-            } catch(\Geocoder\Exception\Exception $e) {
+            } catch(\Exception $e) {
                 // todo log?   
             }
         }

--- a/Doctrine/ORM/GeocoderListener.php
+++ b/Doctrine/ORM/GeocoderListener.php
@@ -86,12 +86,19 @@ class GeocoderListener implements EventSubscriber
     {
         $metadata = $this->driver->loadMetadataFromObject($entity);
         $address = $metadata->addressProperty->getValue($entity);
-        $results = $this->geocoder->geocodeQuery(GeocodeQuery::create($address));
+        if (!empty($address)) {
+            try {
+                 $results = $this->geocoder->geocodeQuery(GeocodeQuery::create($address));
 
-        if (!empty($results)) {
-            $result = $results->first();
-            $metadata->latitudeProperty->setValue($entity, $result->getCoordinates()->getLatitude());
-            $metadata->longitudeProperty->setValue($entity, $result->getCoordinates()->getLongitude());
+                if (!empty($results)) {
+                    $result = $results->first();
+                    $metadata->latitudeProperty->setValue($entity, $result->getCoordinates()->getLatitude());
+                    $metadata->longitudeProperty->setValue($entity, $result->getCoordinates()->getLongitude());
+                }
+            } catch(\Geocoder\Exception\Exception $e) {
+                // todo log?   
+            }
         }
+       
     }
 }

--- a/Mapping/Driver/AnnotationDriver.php
+++ b/Mapping/Driver/AnnotationDriver.php
@@ -31,14 +31,27 @@ class AnnotationDriver implements DriverInterface
 
     public function isGeocodeable($object): bool
     {
-        $reflection = new \ReflectionObject($object);
+        $reflection = new \ReflectionClass($object);
+
+        // check if object is a doctrine proxy object
+        if ($object instanceof \Doctrine\Common\Persistence\Proxy) {
+            // This gets the real object, the one that the Proxy extends
+            $reflection = $reflection->getParentClass();
+        }
 
         return (bool) $this->reader->getClassAnnotation($reflection, Annotations\Geocodeable::class);
     }
 
     public function loadMetadataFromObject($object)
     {
-        $reflection = new \ReflectionObject($object);
+         $reflection = new \ReflectionClass($object);
+
+        // check if object is a doctrine proxy object
+        if ($object instanceof \Doctrine\Common\Persistence\Proxy) {
+            // This gets the real object, the one that the Proxy extends
+            $reflection = $reflection->getParentClass();
+        }
+        
         if (!$annotation = $this->reader->getClassAnnotation($reflection, Annotations\Geocodeable::class)) {
             throw new Exception\MappingException(sprintf(
                 'The class %s is not geocodeable', get_class($object)


### PR DESCRIPTION
Fixed problem where geocoding was not performed, when the changed entity was proxied by Doctrine.

Also prevented error if the value of the address property or the result of the geocoding query was empty.