### PR TITLE
Address annotation can be used over a getter

### DIFF
--- a/Doctrine/ORM/GeocoderListener.php
+++ b/Doctrine/ORM/GeocoderListener.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Bazinga\GeocoderBundle\Doctrine\ORM;
 
+use Bazinga\GeocoderBundle\Mapping\ClassMetadata;
 use Bazinga\GeocoderBundle\Mapping\Driver\DriverInterface;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\OnFlushEventArgs;
@@ -84,8 +85,15 @@ class GeocoderListener implements EventSubscriber
 
     private function geocodeEntity($entity)
     {
+        /** @var ClassMetadata $metadata */
         $metadata = $this->driver->loadMetadataFromObject($entity);
-        $address = $metadata->addressProperty->getValue($entity);
+
+        if (null !== $metadata->addressGetter) {
+            $address = $metadata->addressGetter->invoke($entity);
+        } else {
+            $address = $metadata->addressProperty->getValue($entity);
+        }
+
         $results = $this->geocoder->geocodeQuery(GeocodeQuery::create($address));
 
         if (!empty($results)) {

--- a/Mapping/ClassMetadata.php
+++ b/Mapping/ClassMetadata.php
@@ -31,4 +31,9 @@ class ClassMetadata
      * @var \ReflectionProperty
      */
     public $longitudeProperty;
+
+    /**
+     * @var \ReflectionMethod
+     */
+    public $addressGetter;
 }

--- a/Mapping/Driver/AnnotationDriver.php
+++ b/Mapping/Driver/AnnotationDriver.php
@@ -62,6 +62,16 @@ class AnnotationDriver implements DriverInterface
             }
         }
 
+        foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($this->reader->getMethodAnnotation($method, Annotations\Address::class)) {
+                if (0 !== $method->getNumberOfRequiredParameters()) {
+                    throw new \Exception('You can not use a method requiring parameters with @Address annotation!');
+                }
+
+                $metadata->addressGetter = $method;
+            }
+        }
+
         return $metadata;
     }
 }

--- a/Resources/doc/doctrine.md
+++ b/Resources/doc/doctrine.md
@@ -34,6 +34,37 @@ class User
 }
 ```
 
+Instead of annotating a property, you can also annotate a getter:
+
+```php
+
+use Bazinga\GeocoderBundle\Mapping\Annotations as Geocoder;
+
+/**
+ * @Geocoder\Geocodeable
+ */
+class User
+{
+    /**
+     * @Geocoder\Latitude
+     */
+    private $latitude;
+
+    /**
+     * @Geocoder\Longitude
+     */
+    private $longitude;
+    
+    /**
+     * @Geocoder\Address
+     */
+    public function getAddress(): string
+    {
+        // Your code...
+    }
+}
+```
+
 Secondly, register the Doctrine event listener and its dependencies in your `services.yaml` file.  
 You have to indicate which provider to use to reverse geocode the address. Here we use `acme` provider we declared in bazinga_geocoder configuration earlier.
 


### PR DESCRIPTION
Hello,

Following #217, the `Address` annotation can now be used over a method (a getter).  
The method must be public, and it can has any name / any return type.  
It can't have required arguments, though, otherwise an exception will be thrown to indicate the annotation is erroneously used.

No BC breaks, some documentation was added.