### PR TITLE
Skip empty address values in listener

### DIFF
--- a/Doctrine/ORM/GeocoderListener.php
+++ b/Doctrine/ORM/GeocoderListener.php
@@ -94,6 +94,10 @@ class GeocoderListener implements EventSubscriber
             $address = $metadata->addressProperty->getValue($entity);
         }
 
+        if (empty($address)) {
+            return;
+        }
+
         $results = $this->geocoder->geocodeQuery(GeocodeQuery::create($address));
 
         if (!empty($results)) {

--- a/Tests/Doctrine/ORM/GeocoderListenerTest.php
+++ b/Tests/Doctrine/ORM/GeocoderListenerTest.php
@@ -75,6 +75,7 @@ class GeocoderListenerTest extends OrmTestCase
         $sm = new SchemaTool($this->em);
         $sm->createSchema([
             $this->em->getClassMetadata('Bazinga\GeocoderBundle\Tests\Doctrine\ORM\DummyWithProperty'),
+            $this->em->getClassMetadata('Bazinga\GeocoderBundle\Tests\Doctrine\ORM\DummyWithEmptyProperty'),
             $this->em->getClassMetadata('Bazinga\GeocoderBundle\Tests\Doctrine\ORM\DummyWithGetter'),
             $this->em->getClassMetadata('Bazinga\GeocoderBundle\Tests\Doctrine\ORM\DummyWithInvalidGetter'),
         ]);
@@ -132,6 +133,18 @@ class GeocoderListenerTest extends OrmTestCase
         $this->expectException(\Exception::class);
 
         $this->em->flush();
+    }
+
+    public function testPersistForEmptyProperty()
+    {
+        $dummy = new DummyWithEmptyProperty();
+        $dummy->address = '';
+
+        $this->em->persist($dummy);
+        $this->em->flush();
+
+        $this->assertNull($dummy->latitude);
+        $this->assertNull($dummy->longitude);
     }
 }
 
@@ -290,4 +303,35 @@ class DummyWithInvalidGetter
     {
         $this->longitude = $longitude;
     }
+}
+
+/**
+ * @Geocodeable
+ * @Entity
+ */
+class DummyWithEmptyProperty
+{
+    /**
+     * @Id @GeneratedValue
+     * @Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @Latitude
+     * @Column(nullable=true)
+     */
+    public $latitude;
+
+    /**
+     * @Longitude
+     * @Column(nullable=true)
+     */
+    public $longitude;
+
+    /**
+     * @Address
+     * @Column
+     */
+    public $address;
 }


### PR DESCRIPTION
When you have and entity with an optional address field, the listener should only fetch coordinates when the address is actually filled in.