### PR TITLE
Fix extension cannot replace non-defined argument

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -21,7 +21,7 @@ services:
 
     Bazinga\GeocoderBundle\Plugin\FakeIpPlugin:
         class: Bazinga\GeocoderBundle\Plugin\FakeIpPlugin
-        arguments: ['127.0.0.1', ~]
+        arguments: ['127.0.0.1', ~, false]
 
     Bazinga\GeocoderBundle\Command\GeocodeCommand:
         arguments: ['@Geocoder\ProviderAggregator']


### PR DESCRIPTION
Fixing:

```
In Definition.php line 271:

  [Symfony\Component\DependencyInjection\Exception\OutOfBoundsException]
  The index "2" is not in the range [0, 1].

Exception trace:
  at /srv/app/vendor/symfony/dependency-injection/Definition.php:271
 Symfony\Component\DependencyInjection\Definition->replaceArgument() at /srv/app/vendor/willdurand/geocoder-bundle/DependencyInjection/BazingaGeocoderExtension.php:59
```