### PR TITLE
Only trigger provider deprecation notices when they are explicitly configured -- #259.

### DIFF
--- a/ProviderFactory/GeoIPsFactory.php
+++ b/ProviderFactory/GeoIPsFactory.php
@@ -17,8 +17,6 @@ use Geocoder\Provider\Provider;
 use Http\Discovery\HttpClientDiscovery;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-@trigger_error('Bazinga\GeocoderBundle\ProviderFactory\GeoIPsFactory is deprecated since 5.6, to be removed in 6.0. See https://github.com/geocoder-php/Geocoder/issues/965', E_USER_DEPRECATED);
-
 /**
  * @deprecated since 5.6, to be removed in 6.0. See https://github.com/geocoder-php/Geocoder/issues/965
  */
@@ -30,6 +28,8 @@ final class GeoIPsFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
+        @trigger_error('Bazinga\GeocoderBundle\ProviderFactory\GeoIPsFactory is deprecated since 5.6, to be removed in 6.0. See https://github.com/geocoder-php/Geocoder/issues/965', E_USER_DEPRECATED);
+
         $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
 
         return new GeoIPs($httplug, $config['api_key']);

--- a/ProviderFactory/MapzenFactory.php
+++ b/ProviderFactory/MapzenFactory.php
@@ -17,8 +17,6 @@ use Geocoder\Provider\Provider;
 use Http\Discovery\HttpClientDiscovery;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-@trigger_error('Bazinga\GeocoderBundle\ProviderFactory\MapzenFactory is deprecated since 5.6, to be removed in 6.0. See https://github.com/geocoder-php/Geocoder/issues/808', E_USER_DEPRECATED);
-
 /**
  * @deprecated since 5.6, to be removed in 6.0. See https://github.com/geocoder-php/Geocoder/issues/808
  */
@@ -30,6 +28,8 @@ final class MapzenFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
+        @trigger_error('Bazinga\GeocoderBundle\ProviderFactory\MapzenFactory is deprecated since 5.6, to be removed in 6.0. See https://github.com/geocoder-php/Geocoder/issues/808', E_USER_DEPRECATED);
+
         $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
 
         return new Mapzen($httplug, $config['api_key']);


### PR DESCRIPTION
This resolves the deprecation triggering described in #259 while still properly triggering a notice when the provider is explicitly used.