### PR TITLE
replace empty() check in listener

### DIFF
--- a/Doctrine/ORM/GeocoderListener.php
+++ b/Doctrine/ORM/GeocoderListener.php
@@ -100,7 +100,7 @@ class GeocoderListener implements EventSubscriber
 
         $results = $this->geocoder->geocodeQuery(GeocodeQuery::create($address));
 
-        if (!empty($results)) {
+        if (!$results->isEmpty()) {
             $result = $results->first();
             $metadata->latitudeProperty->setValue($entity, $result->getCoordinates()->getLatitude());
             $metadata->longitudeProperty->setValue($entity, $result->getCoordinates()->getLongitude());


### PR DESCRIPTION
when searching for an address that returns no result, an AddressCollection item is returned with no locations inside, which means locations is an empty array, so the next line which reads the first result will cause an exception when there is no location. it is better to use the isEmpty() method of the AddressCollection to no try to access the first entry when there is no such entry