### PR TITLE
Allow an HTTP client to be injected via the constructor of providers

### DIFF
--- a/ProviderFactory/AbstractFactory.php
+++ b/ProviderFactory/AbstractFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\Provider;
+use Http\Client\HttpClient;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -25,6 +26,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 abstract class AbstractFactory implements ProviderFactoryInterface
 {
     protected static $dependencies = [];
+
+    protected $httpClient;
+
+    public function __construct(HttpClient $httpClient = null)
+    {
+        $this->httpClient = $httpClient;
+    }
 
     abstract protected function getProvider(array $config): Provider;
 

--- a/ProviderFactory/AlgoliaFactory.php
+++ b/ProviderFactory/AlgoliaFactory.php
@@ -25,7 +25,7 @@ final class AlgoliaFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new AlgoliaPlaces($httplug, $config['api_key'], $config['app_id']);
     }

--- a/ProviderFactory/ArcGISOnlineFactory.php
+++ b/ProviderFactory/ArcGISOnlineFactory.php
@@ -25,7 +25,7 @@ final class ArcGISOnlineFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new ArcGISOnline($httplug, $config['source_country']);
     }

--- a/ProviderFactory/BingMapsFactory.php
+++ b/ProviderFactory/BingMapsFactory.php
@@ -25,7 +25,7 @@ final class BingMapsFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new BingMaps($httplug, $config['api_key']);
     }

--- a/ProviderFactory/FreeGeoIpFactory.php
+++ b/ProviderFactory/FreeGeoIpFactory.php
@@ -25,7 +25,7 @@ final class FreeGeoIpFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new FreeGeoIp($httplug, $config['base_url']);
     }

--- a/ProviderFactory/GeoIPsFactory.php
+++ b/ProviderFactory/GeoIPsFactory.php
@@ -30,7 +30,7 @@ final class GeoIPsFactory extends AbstractFactory
     {
         @trigger_error('Bazinga\GeocoderBundle\ProviderFactory\GeoIPsFactory is deprecated since 5.6, to be removed in 6.0. See https://github.com/geocoder-php/Geocoder/issues/965', E_USER_DEPRECATED);
 
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new GeoIPs($httplug, $config['api_key']);
     }

--- a/ProviderFactory/GeoPluginFactory.php
+++ b/ProviderFactory/GeoPluginFactory.php
@@ -25,7 +25,7 @@ final class GeoPluginFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new GeoPlugin($httplug);
     }

--- a/ProviderFactory/GeonamesFactory.php
+++ b/ProviderFactory/GeonamesFactory.php
@@ -25,7 +25,7 @@ final class GeonamesFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new Geonames($httplug, $config['username']);
     }

--- a/ProviderFactory/GoogleMapsFactory.php
+++ b/ProviderFactory/GoogleMapsFactory.php
@@ -25,7 +25,7 @@ final class GoogleMapsFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new GoogleMaps($httplug, $config['region'], $config['api_key']);
     }

--- a/ProviderFactory/GoogleMapsPlacesFactory.php
+++ b/ProviderFactory/GoogleMapsPlacesFactory.php
@@ -25,7 +25,7 @@ final class GoogleMapsPlacesFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new GoogleMapsPlaces($httplug, $config['api_key']);
     }

--- a/ProviderFactory/HereFactory.php
+++ b/ProviderFactory/HereFactory.php
@@ -25,7 +25,7 @@ final class HereFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new Here($httplug, $config['app_id'], $config['app_code'], $config['use_cit']);
     }

--- a/ProviderFactory/HostIpFactory.php
+++ b/ProviderFactory/HostIpFactory.php
@@ -25,7 +25,7 @@ final class HostIpFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new HostIp($httplug);
     }

--- a/ProviderFactory/IpInfoDbFactory.php
+++ b/ProviderFactory/IpInfoDbFactory.php
@@ -25,7 +25,7 @@ final class IpInfoDbFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new IpInfoDb($httplug, $config['api_key'], $config['precision']);
     }

--- a/ProviderFactory/IpInfoFactory.php
+++ b/ProviderFactory/IpInfoFactory.php
@@ -25,7 +25,7 @@ final class IpInfoFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new IpInfo($httplug);
     }

--- a/ProviderFactory/IpstackFactory.php
+++ b/ProviderFactory/IpstackFactory.php
@@ -25,7 +25,7 @@ final class IpstackFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new Ipstack($httplug, $config['api_key']);
     }

--- a/ProviderFactory/MapQuestFactory.php
+++ b/ProviderFactory/MapQuestFactory.php
@@ -25,7 +25,7 @@ final class MapQuestFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new MapQuest($httplug, $config['api_key'], $config['licensed']);
     }

--- a/ProviderFactory/MapboxFactory.php
+++ b/ProviderFactory/MapboxFactory.php
@@ -23,7 +23,7 @@ final class MapboxFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new Mapbox($httplug, $config['api_key'], $config['country'], $config['mode']);
     }

--- a/ProviderFactory/MapzenFactory.php
+++ b/ProviderFactory/MapzenFactory.php
@@ -30,7 +30,7 @@ final class MapzenFactory extends AbstractFactory
     {
         @trigger_error('Bazinga\GeocoderBundle\ProviderFactory\MapzenFactory is deprecated since 5.6, to be removed in 6.0. See https://github.com/geocoder-php/Geocoder/issues/808', E_USER_DEPRECATED);
 
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new Mapzen($httplug, $config['api_key']);
     }

--- a/ProviderFactory/MaxMindFactory.php
+++ b/ProviderFactory/MaxMindFactory.php
@@ -25,7 +25,7 @@ final class MaxMindFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new MaxMind($httplug, $config['api_key'], $config['endpoint']);
     }

--- a/ProviderFactory/NominatimFactory.php
+++ b/ProviderFactory/NominatimFactory.php
@@ -25,7 +25,7 @@ final class NominatimFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new Nominatim($httplug, $config['root_url'], $config['user_agent']);
     }

--- a/ProviderFactory/OpenCageFactory.php
+++ b/ProviderFactory/OpenCageFactory.php
@@ -25,7 +25,7 @@ final class OpenCageFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new OpenCage($httplug, $config['api_key']);
     }

--- a/ProviderFactory/PickPointFactory.php
+++ b/ProviderFactory/PickPointFactory.php
@@ -25,7 +25,7 @@ final class PickPointFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new PickPoint($httplug, $config['api_key']);
     }

--- a/ProviderFactory/TomTomFactory.php
+++ b/ProviderFactory/TomTomFactory.php
@@ -25,7 +25,7 @@ final class TomTomFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new TomTom($httplug, $config['api_key']);
     }

--- a/ProviderFactory/YandexFactory.php
+++ b/ProviderFactory/YandexFactory.php
@@ -25,7 +25,7 @@ final class YandexFactory extends AbstractFactory
 
     protected function getProvider(array $config): Provider
     {
-        $httplug = $config['httplug_client'] ?: HttpClientDiscovery::find();
+        $httplug = $config['httplug_client'] ?: $this->httpClient ?? HttpClientDiscovery::find();
 
         return new Yandex($httplug, $config['toponym'], $config['api_key']);
     }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -14,6 +14,7 @@ services:
     Bazinga\GeocoderBundle\ProviderFactory\:
         resource: '../../ProviderFactory'
         public: false
+        autowire: true
         autoconfigure: true
 
     Geocoder\ProviderAggregator:

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
     "nyholm/symfony-bundle-test": "^1.6.1",
     "php-http/curl-client": "^1.7",
     "php-http/message": "^1.5",
+    "symfony/config": ">=3.4.31",
     "symfony/phpunit-bridge": "^4.4",
     "symfony/validator": "^3.4 || ^4.2 || ^5.0",
     "symfony/yaml": "^3.4 || ^4.2 || ^5.0"


### PR DESCRIPTION
This allows leveraging the new `HttplugClient` of the Symfony HttpClient when possible, instead of having to use static discovery when not using HttplugBundle.