### PR TITLE
Add support for PHP 8 attributes

### DIFF
--- a/Mapping/Annotations/Address.php
+++ b/Mapping/Annotations/Address.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Bazinga\GeocoderBundle\Mapping\Annotations;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD)]
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  *

--- a/Mapping/Annotations/Geocodeable.php
+++ b/Mapping/Annotations/Geocodeable.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Bazinga\GeocoderBundle\Mapping\Annotations;
 
+#[\Attribute(\Attribute::TARGET_CLASS)]
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  *

--- a/Mapping/Annotations/Latitude.php
+++ b/Mapping/Annotations/Latitude.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Bazinga\GeocoderBundle\Mapping\Annotations;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  *

--- a/Mapping/Annotations/Longitude.php
+++ b/Mapping/Annotations/Longitude.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Bazinga\GeocoderBundle\Mapping\Annotations;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  *

--- a/Mapping/Driver/AttributeDriver.php
+++ b/Mapping/Driver/AttributeDriver.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the BazingaGeocoderBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Bazinga\GeocoderBundle\Mapping\Driver;
+
+use Bazinga\GeocoderBundle\Mapping\Annotations;
+use Bazinga\GeocoderBundle\Mapping\ClassMetadata;
+use Bazinga\GeocoderBundle\Mapping\Exception\MappingException;
+use Doctrine\Common\Util\ClassUtils;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ */
+final class AttributeDriver implements DriverInterface
+{
+    public function isGeocodeable($object): bool
+    {
+        if (PHP_VERSION_ID < 80000) {
+            return false;
+        }
+
+        $reflection = ClassUtils::newReflectionObject($object);
+
+        return count($reflection->getAttributes(Annotations\Geocodeable::class)) > 0;
+    }
+
+    /**
+     * @throws MappingException
+     */
+    public function loadMetadataFromObject($object): ClassMetadata
+    {
+        if (PHP_VERSION_ID < 80000) {
+            throw new MappingException(sprintf('The class %s is not geocodeable', get_class($object)));
+        }
+
+        $reflection = ClassUtils::newReflectionObject($object);
+
+        $attributes = $reflection->getAttributes(Annotations\Geocodeable::class);
+
+        if (0 === count($attributes)) {
+            throw new MappingException(sprintf('The class %s is not geocodeable', get_class($object)));
+        }
+
+        $metadata = new ClassMetadata();
+
+        foreach ($reflection->getProperties() as $property) {
+            foreach ($property->getAttributes() as $attribute) {
+                if (Annotations\Latitude::class === $attribute->getName()) {
+                    $property->setAccessible(true);
+                    $metadata->latitudeProperty = $property;
+                } elseif (Annotations\Longitude::class === $attribute->getName()) {
+                    $property->setAccessible(true);
+                    $metadata->longitudeProperty = $property;
+                } elseif (Annotations\Address::class === $attribute->getName()) {
+                    $property->setAccessible(true);
+                    $metadata->addressProperty = $property;
+                }
+            }
+        }
+
+        foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            if (count($method->getAttributes(Annotations\Address::class)) > 0) {
+                if (0 !== $method->getNumberOfRequiredParameters()) {
+                    throw new MappingException('You can not use a method requiring parameters with #[Address] attribute!');
+                }
+
+                $metadata->addressGetter = $method;
+            }
+        }
+
+        return $metadata;
+    }
+}

--- a/Resources/doc/doctrine.md
+++ b/Resources/doc/doctrine.md
@@ -96,3 +96,40 @@ $em->flush();
 echo $user->getLatitude(); // will output 52.516325
 echo $user->getLongitude(); // will output 13.377264
 ```
+
+## PHP 8
+
+If you are using PHP 8, you can use [Attributes](https://www.php.net/manual/en/language.attributes.overview.php) in your entity:
+
+```php
+
+use Bazinga\GeocoderBundle\Mapping\Annotations as Geocoder;
+
+#[Geocoder\Geocodeable()]
+class User
+{
+    #[Geocoder\Address()]
+    private $address;
+
+    #[Geocoder\Latitude()]
+    private $latitude;
+
+    #[Geocoder\Longitude()]
+    private $longitude;
+}
+```
+
+Then update your service configuration to register the `AttributeDriver`:
+
+```yaml
+    Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver:
+        class: Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver
+
+    Bazinga\GeocoderBundle\Doctrine\ORM\GeocoderListener:
+        class: Bazinga\GeocoderBundle\Doctrine\ORM\GeocoderListener
+        arguments:
+            - '@bazinga_geocoder.provider.acme'
+            - '@Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver'
+        tags:
+            - doctrine.event_subscriber
+```

--- a/Tests/Mapping/Driver/AttributeDriverTest.php
+++ b/Tests/Mapping/Driver/AttributeDriverTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the BazingaGeocoderBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Bazinga\GeocoderBundle\Tests\Mapping\Driver;
+
+use Bazinga\GeocoderBundle\Mapping\Annotations\Address;
+use Bazinga\GeocoderBundle\Mapping\Annotations\Geocodeable;
+use Bazinga\GeocoderBundle\Mapping\Annotations\Latitude;
+use Bazinga\GeocoderBundle\Mapping\Annotations\Longitude;
+use Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver;
+use Bazinga\GeocoderBundle\Mapping\Exception\MappingException;
+use Doctrine\Common\Annotations\Reader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ */
+final class AttributeDriverTest extends TestCase
+{
+    use SetUpTearDownTrait;
+
+    /**
+     * @var AttributeDriver
+     */
+    private $driver;
+
+    /**
+     * @var Reader
+     */
+    private $reader;
+
+    public static function doSetUpBeforeClass(): void
+    {
+        if (PHP_VERSION_ID < 80000) {
+            self::markTestSkipped(sprintf('"%s" is only supported on PHP 8', AttributeDriver::class));
+        }
+    }
+
+    protected function doSetUp(): void
+    {
+        $this->driver = new AttributeDriver();
+    }
+
+    public function testLoadMetadata()
+    {
+        $obj = new Dummy3();
+        $metadata = $this->driver->loadMetadataFromObject($obj);
+
+        $this->assertInstanceOf('ReflectionProperty', $metadata->addressProperty);
+        $this->assertInstanceOf('ReflectionProperty', $metadata->latitudeProperty);
+        $this->assertInstanceOf('ReflectionProperty', $metadata->longitudeProperty);
+    }
+
+    public function testLoadMetadataFromWrongObject()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('The class '.Dummy4::class.' is not geocodeable');
+
+        $this->driver->loadMetadataFromObject(new Dummy4());
+    }
+
+    public function testIsGeocodable()
+    {
+        $this->assertTrue($this->driver->isGeocodeable(new Dummy3()));
+    }
+}
+
+#[Geocodeable()]
+class Dummy3
+{
+    #[Latitude()]
+    public $latitude;
+
+    #[Longitude()]
+    public $longitude;
+
+    #[Address()]
+    public $address;
+}
+
+class Dummy4
+{
+}


### PR DESCRIPTION
This adds support to use PHP 8 attributes for an entity instead of annotations.

E.G

```php
use Bazinga\GeocoderBundle\Mapping\Annotations as Geocoder;

#[Geocoder\Geocodeable()]
class User
{
    #[Geocoder\Address()]
    private $address;

    #[Geocoder\Latitude()]
    private $latitude;

    #[Geocoder\Longitude()]
    private $longitude;
}
```
