### PR TITLE
Auto register doctrine services

### DIFF
--- a/DependencyInjection/BazingaGeocoderExtension.php
+++ b/DependencyInjection/BazingaGeocoderExtension.php
@@ -53,6 +53,10 @@ class BazingaGeocoderExtension extends Extension
             $loader->load('profiling.yml');
         }
 
+        if (array_key_exists('DoctrineBundle', $container->getParameter('kernel.bundles'))) {
+            $loader->load('doctrine.yml');
+        }
+
         if ($config['fake_ip']['enabled']) {
             $definition = $container->getDefinition(FakeIpPlugin::class);
             $definition->replaceArgument(0, $config['fake_ip']['local_ip']);

--- a/Doctrine/ORM/GeocodeEntityListener.php
+++ b/Doctrine/ORM/GeocodeEntityListener.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the BazingaGeocoderBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Bazinga\GeocoderBundle\Doctrine\ORM;
+
+use Bazinga\GeocoderBundle\Mapping\ClassMetadata;
+use Bazinga\GeocoderBundle\Mapping\Driver\DriverInterface;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\UnitOfWork;
+use Geocoder\Query\GeocodeQuery;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+/**
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ * @author Pierre du Plessis <pdples@gmail.com>
+ */
+class GeocodeEntityListener implements EventSubscriber
+{
+    /**
+     * @var DriverInterface
+     */
+    private $driver;
+
+    /**
+     * @var ServiceLocator
+     */
+    private $providerLocator;
+
+    public function __construct(ServiceLocator $providerLocator, DriverInterface $driver)
+    {
+        $this->driver = $driver;
+        $this->providerLocator = $providerLocator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubscribedEvents()
+    {
+        return [
+            Events::onFlush,
+        ];
+    }
+
+    public function onFlush(OnFlushEventArgs $args)
+    {
+        $em = $args->getEntityManager();
+        $uow = $em->getUnitOfWork();
+
+        foreach ($uow->getScheduledEntityInsertions() as $entity) {
+            if (!$this->driver->isGeocodeable($entity)) {
+                continue;
+            }
+
+            /** @var ClassMetadata $metadata */
+            $metadata = $this->driver->loadMetadataFromObject($entity);
+
+            $this->geocodeEntity($metadata, $entity);
+
+            $uow->recomputeSingleEntityChangeSet(
+                $em->getClassMetadata(get_class($entity)),
+                $entity
+            );
+        }
+
+        foreach ($uow->getScheduledEntityUpdates() as $entity) {
+            if (!$this->driver->isGeocodeable($entity)) {
+                continue;
+            }
+
+            /** @var ClassMetadata $metadata */
+            $metadata = $this->driver->loadMetadataFromObject($entity);
+
+            if (!$this->shouldGeocode($metadata, $uow, $entity)) {
+                continue;
+            }
+
+            $this->geocodeEntity($metadata, $entity);
+
+            $uow->recomputeSingleEntityChangeSet(
+                $em->getClassMetadata(get_class($entity)),
+                $entity
+            );
+        }
+    }
+
+    /**
+     * @param object $entity
+     */
+    private function geocodeEntity(ClassMetadata $metadata, $entity)
+    {
+        if (null !== $metadata->addressGetter) {
+            $address = $metadata->addressGetter->invoke($entity);
+        } else {
+            $address = $metadata->addressProperty->getValue($entity);
+        }
+
+        if (empty($address)) {
+            return;
+        }
+
+        $serviceId = sprintf('bazinga_geocoder.provider.%s', $metadata->provider);
+
+        if (!$this->providerLocator->has($serviceId)) {
+            throw new \RuntimeException(sprintf('The provider "%s" is invalid for object "%s".', $metadata->provider, get_class($entity)));
+        }
+
+        $results = $this->providerLocator->get($serviceId)->geocodeQuery(GeocodeQuery::create($address));
+
+        if (!$results->isEmpty()) {
+            $result = $results->first();
+            $metadata->latitudeProperty->setValue($entity, $result->getCoordinates()->getLatitude());
+            $metadata->longitudeProperty->setValue($entity, $result->getCoordinates()->getLongitude());
+        }
+    }
+
+    /**
+     * @param object $entity
+     */
+    private function shouldGeocode(ClassMetadata $metadata, UnitOfWork $unitOfWork, $entity): bool
+    {
+        if (null !== $metadata->addressGetter) {
+            return true;
+        }
+
+        $changeSet = $unitOfWork->getEntityChangeSet($entity);
+
+        return isset($changeSet[$metadata->addressProperty->getName()]);
+    }
+}

--- a/Doctrine/ORM/GeocoderListener.php
+++ b/Doctrine/ORM/GeocoderListener.php
@@ -12,123 +12,26 @@ declare(strict_types=1);
 
 namespace Bazinga\GeocoderBundle\Doctrine\ORM;
 
-use Bazinga\GeocoderBundle\Mapping\ClassMetadata;
 use Bazinga\GeocoderBundle\Mapping\Driver\DriverInterface;
-use Doctrine\Common\EventSubscriber;
-use Doctrine\ORM\Event\OnFlushEventArgs;
-use Doctrine\ORM\Events;
-use Doctrine\ORM\UnitOfWork;
 use Geocoder\Provider\Provider;
-use Geocoder\Query\GeocodeQuery;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  */
-class GeocoderListener implements EventSubscriber
+class GeocoderListener extends GeocodeEntityListener
 {
-    /**
-     * @var DriverInterface
-     */
-    private $driver;
-
-    /**
-     * @var Provider
-     */
-    private $geocoder;
-
     public function __construct(Provider $geocoder, DriverInterface $driver)
     {
-        $this->driver = $driver;
-        $this->geocoder = $geocoder;
-    }
+        @trigger_error(sprintf('The class "%s" is deprecated and will be removed from a future version. Please remove it from your service definition.', self::class));
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getSubscribedEvents()
-    {
-        return [
-            Events::onFlush,
-        ];
-    }
-
-    public function onFlush(OnFlushEventArgs $args)
-    {
-        $em = $args->getEntityManager();
-        $uow = $em->getUnitOfWork();
-
-        foreach ($uow->getScheduledEntityInsertions() as $entity) {
-            if (!$this->driver->isGeocodeable($entity)) {
-                continue;
+        $locator = new ServiceLocator(array(
+            'bazinga_geocoder.provider.' =>
+            function () use ($geocoder) {
+                return $geocoder;
             }
+        ));
 
-            /** @var ClassMetadata $metadata */
-            $metadata = $this->driver->loadMetadataFromObject($entity);
-
-            $this->geocodeEntity($metadata, $entity);
-
-            $uow->recomputeSingleEntityChangeSet(
-                $em->getClassMetadata(get_class($entity)),
-                $entity
-            );
-        }
-
-        foreach ($uow->getScheduledEntityUpdates() as $entity) {
-            if (!$this->driver->isGeocodeable($entity)) {
-                continue;
-            }
-
-            /** @var ClassMetadata $metadata */
-            $metadata = $this->driver->loadMetadataFromObject($entity);
-
-            if (!$this->shouldGeocode($metadata, $uow, $entity)) {
-                continue;
-            }
-
-            $this->geocodeEntity($metadata, $entity);
-
-            $uow->recomputeSingleEntityChangeSet(
-                $em->getClassMetadata(get_class($entity)),
-                $entity
-            );
-        }
-    }
-
-    /**
-     * @param object $entity
-     */
-    private function geocodeEntity(ClassMetadata $metadata, $entity)
-    {
-        if (null !== $metadata->addressGetter) {
-            $address = $metadata->addressGetter->invoke($entity);
-        } else {
-            $address = $metadata->addressProperty->getValue($entity);
-        }
-
-        if (empty($address)) {
-            return;
-        }
-
-        $results = $this->geocoder->geocodeQuery(GeocodeQuery::create($address));
-
-        if (!$results->isEmpty()) {
-            $result = $results->first();
-            $metadata->latitudeProperty->setValue($entity, $result->getCoordinates()->getLatitude());
-            $metadata->longitudeProperty->setValue($entity, $result->getCoordinates()->getLongitude());
-        }
-    }
-
-    /**
-     * @param object $entity
-     */
-    private function shouldGeocode(ClassMetadata $metadata, UnitOfWork $unitOfWork, $entity): bool
-    {
-        if (null !== $metadata->addressGetter) {
-            return true;
-        }
-
-        $changeSet = $unitOfWork->getEntityChangeSet($entity);
-
-        return isset($changeSet[$metadata->addressProperty->getName()]);
+        parent::__construct($locator, $driver);
     }
 }

--- a/Mapping/Annotations/Address.php
+++ b/Mapping/Annotations/Address.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Bazinga\GeocoderBundle\Mapping\Annotations;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD)]
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  *

--- a/Mapping/Annotations/Geocodeable.php
+++ b/Mapping/Annotations/Geocodeable.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Bazinga\GeocoderBundle\Mapping\Annotations;
 
+#[\Attribute(\Attribute::TARGET_CLASS)]
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  *

--- a/Mapping/Annotations/Latitude.php
+++ b/Mapping/Annotations/Latitude.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Bazinga\GeocoderBundle\Mapping\Annotations;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  *

--- a/Mapping/Annotations/Longitude.php
+++ b/Mapping/Annotations/Longitude.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Bazinga\GeocoderBundle\Mapping\Annotations;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  *

--- a/Mapping/ClassMetadata.php
+++ b/Mapping/ClassMetadata.php
@@ -36,4 +36,9 @@ class ClassMetadata
      * @var \ReflectionMethod
      */
     public $addressGetter;
+
+    /**
+     * @var string|null
+     */
+    public $provider = null;
 }

--- a/Mapping/Driver/AnnotationDriver.php
+++ b/Mapping/Driver/AnnotationDriver.php
@@ -44,6 +44,7 @@ class AnnotationDriver implements DriverInterface
         }
 
         $metadata = new ClassMetadata();
+        $metadata->provider = $annotation->provider;
 
         foreach ($reflection->getProperties() as $property) {
             foreach ($this->reader->getPropertyAnnotations($property) as $annotation) {

--- a/Mapping/Driver/AttributeDriver.php
+++ b/Mapping/Driver/AttributeDriver.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the BazingaGeocoderBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Bazinga\GeocoderBundle\Mapping\Driver;
+
+use Bazinga\GeocoderBundle\Mapping\Annotations;
+use Bazinga\GeocoderBundle\Mapping\ClassMetadata;
+use Bazinga\GeocoderBundle\Mapping\Exception\MappingException;
+use Doctrine\Persistence\Proxy;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ */
+class AttributeDriver implements DriverInterface
+{
+    public function isGeocodeable($object): bool
+    {
+        if (PHP_VERSION_ID < 80000) {
+            return false;
+        }
+
+        $reflection = new \ReflectionObject($object);
+
+        if ($object instanceof Proxy) {
+            $reflection = $reflection->getParentClass();
+        }
+
+        return [] !== $reflection->getAttributes(Annotations\Geocodeable::class);
+    }
+
+    /**
+     * @throws MappingException
+     */
+    public function loadMetadataFromObject($object): ClassMetadata
+    {
+        if (PHP_VERSION_ID < 80000) {
+            throw new MappingException(sprintf('The class %s is not geocodeable', get_class($object)));
+        }
+
+        $reflection = new \ReflectionObject($object);
+
+        if ($object instanceof Proxy) {
+            $reflection = $reflection->getParentClass();
+        }
+
+        $attributes = $reflection->getAttributes(Annotations\Geocodeable::class);
+
+        if ([] === $attributes) {
+            throw new MappingException(sprintf('The class %s is not geocodeable', get_class($object)));
+        }
+
+        $metadata = new ClassMetadata();
+
+        foreach ($reflection->getProperties() as $property) {
+            foreach ($property->getAttributes() as $attribute) {
+
+                if ($attribute->getName() === Annotations\Latitude::class) {
+                    $property->setAccessible(true);
+                    $metadata->latitudeProperty = $property;
+                } elseif ($attribute->getName() === Annotations\Longitude::class) {
+                    $property->setAccessible(true);
+                    $metadata->longitudeProperty = $property;
+                } elseif ($attribute->getName() === Annotations\Address::class) {
+                    $property->setAccessible(true);
+                    $metadata->addressProperty = $property;
+                }
+            }
+        }
+
+        foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            if ([] !== $method->getAttributes(Annotations\Address::class)) {
+                if (0 !== $method->getNumberOfRequiredParameters()) {
+                    throw new MappingException('You can not use a method requiring parameters with #[Address] attribute!');
+                }
+
+                $metadata->addressGetter = $method;
+            }
+        }
+
+        return $metadata;
+    }
+}

--- a/Mapping/Driver/AttributeDriver.php
+++ b/Mapping/Driver/AttributeDriver.php
@@ -59,6 +59,7 @@ class AttributeDriver implements DriverInterface
         }
 
         $metadata = new ClassMetadata();
+        $metadata->provider = $attributes[0]->newInstance()->provider;
 
         foreach ($reflection->getProperties() as $property) {
             foreach ($property->getAttributes() as $attribute) {

--- a/Mapping/Driver/ChainDriver.php
+++ b/Mapping/Driver/ChainDriver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the BazingaGeocoderBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Bazinga\GeocoderBundle\Mapping\Driver;
+
+use Bazinga\GeocoderBundle\Mapping\Annotations;
+use Bazinga\GeocoderBundle\Mapping\ClassMetadata;
+use Bazinga\GeocoderBundle\Mapping\Exception;
+use Bazinga\GeocoderBundle\Mapping\Exception\MappingException;
+use Doctrine\Common\Annotations\Reader;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ */
+class ChainDriver implements DriverInterface
+{
+    private $drivers;
+
+    public function __construct(iterable $drivers)
+    {
+        $this->drivers = $drivers;
+    }
+
+    public function isGeocodeable($object): bool
+    {
+        foreach ($this->drivers as $driver) {
+            if ($driver->isGeocodeable($object)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function loadMetadataFromObject($object)
+    {
+        foreach ($this->drivers as $driver) {
+            try {
+                return $driver->loadMetadataFromObject($object);
+            } catch (MappingException $exception) {
+                continue;
+            }
+        }
+
+        throw new MappingException(sprintf('The class %s is not geocodeable', get_class($object)));
+    }
+}

--- a/Mapping/Driver/DriverInterface.php
+++ b/Mapping/Driver/DriverInterface.php
@@ -12,9 +12,14 @@ declare(strict_types=1);
 
 namespace Bazinga\GeocoderBundle\Mapping\Driver;
 
+use Bazinga\GeocoderBundle\Mapping\Exception\MappingException;
+
 interface DriverInterface
 {
     public function isGeocodeable($object): bool;
 
+    /**
+     * @throws MappingException
+     */
     public function loadMetadataFromObject($object);
 }

--- a/Resources/config/doctrine.yml
+++ b/Resources/config/doctrine.yml
@@ -1,0 +1,15 @@
+services:
+    Bazinga\GeocoderBundle\Mapping\Driver\AnnotationDriver:
+        class: Bazinga\GeocoderBundle\Mapping\Driver\AnnotationDriver
+        arguments:
+            - '@annotations.reader'
+        tags:
+            - { name: bazinga_geocoder.metadata.driver }
+
+    Bazinga\GeocoderBundle\Doctrine\ORM\GeocoderListener:
+        class: Bazinga\GeocoderBundle\Doctrine\ORM\GeocoderListener
+        arguments:
+            - !tagged_locator 'bazinga_geocoder.provider'
+            - '@Bazinga\GeocoderBundle\Mapping\Driver\DriverInterface'
+        tags:
+            - doctrine.event_subscriber

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -38,3 +38,15 @@ services:
 
     geocoder:
         alias: "Geocoder\\ProviderAggregator"
+
+    Bazinga\GeocoderBundle\Mapping\Driver\ChainDriver:
+        class: Bazinga\GeocoderBundle\Mapping\Driver\ChainDriver
+        arguments:
+            - !tagged_iterator bazinga_geocoder.metadata.driver
+
+    Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver:
+        class: Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver
+        tags:
+            - { name: bazinga_geocoder.metadata.driver }
+
+    Bazinga\GeocoderBundle\Mapping\Driver\DriverInterface: '@Bazinga\GeocoderBundle\Mapping\Driver\ChainDriver'

--- a/Resources/doc/doctrine.md
+++ b/Resources/doc/doctrine.md
@@ -65,41 +65,7 @@ class User
 }
 ```
 
-Secondly, register the Doctrine event listener and its dependencies in your `services.yaml` file.  
-You have to indicate which provider to use to reverse geocode the address. Here we use `acme` provider we declared in bazinga_geocoder configuration earlier.
-
-```yaml
-    Bazinga\GeocoderBundle\Mapping\Driver\AnnotationDriver:
-        class: Bazinga\GeocoderBundle\Mapping\Driver\AnnotationDriver
-        arguments:
-            - '@annotations.reader'
-
-    Bazinga\GeocoderBundle\Doctrine\ORM\GeocoderListener:
-        class: Bazinga\GeocoderBundle\Doctrine\ORM\GeocoderListener
-        arguments:
-            - '@bazinga_geocoder.provider.acme'
-            - '@Bazinga\GeocoderBundle\Mapping\Driver\AnnotationDriver'
-        tags:
-            - doctrine.event_subscriber
-```
-
-It is done!  
-Now you can use it:
-
-```php
-$user = new User();
-$user->setAddress('Brandenburger Tor, Pariser Platz, Berlin');
-
-$em->persist($event);
-$em->flush();
-
-echo $user->getLatitude(); // will output 52.516325
-echo $user->getLongitude(); // will output 13.377264
-```
-
-## PHP 8
-
-If you are using PHP 8, you can use [Attributes](https://www.php.net/manual/en/language.attributes.overview.php) in your entity:
+If you are using PHP 8, then you can use [Attributes](https://www.php.net/manual/en/language.attributes.overview.php) in your entity:
 
 ```php
 
@@ -119,17 +85,15 @@ class User
 }
 ```
 
-Then update your service configuration to register the `AttributeDriver`:
+It is done!  
+Now you can use it:
 
-```yaml
-    Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver:
-        class: Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver
+```php
+$user = new User();
+$user->setAddress('Brandenburger Tor, Pariser Platz, Berlin');
+$em->persist($event);
+$em->flush();
 
-    Bazinga\GeocoderBundle\Doctrine\ORM\GeocoderListener:
-        class: Bazinga\GeocoderBundle\Doctrine\ORM\GeocoderListener
-        arguments:
-            - '@bazinga_geocoder.provider.acme'
-            - '@Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver'
-        tags:
-            - doctrine.event_subscriber
+echo $user->getLatitude(); // will output 52.516325
+echo $user->getLongitude(); // will output 13.377264
 ```

--- a/Resources/doc/doctrine.md
+++ b/Resources/doc/doctrine.md
@@ -96,3 +96,40 @@ $em->flush();
 echo $user->getLatitude(); // will output 52.516325
 echo $user->getLongitude(); // will output 13.377264
 ```
+
+## PHP 8
+
+If you are using PHP 8, you can use [Attributes](https://www.php.net/manual/en/language.attributes.overview.php) in your entity:
+
+```php
+
+use Bazinga\GeocoderBundle\Mapping\Annotations as Geocoder;
+
+#[Geocoder\Geocodeable()]
+class User
+{
+    #[Geocoder\Address()]
+    private $address;
+
+    #[Geocoder\Latitude()]
+    private $latitude;
+
+    #[Geocoder\Longitude()]
+    private $longitude;
+}
+```
+
+Then update your service configuration to register the `AttributeDriver`:
+
+```yaml
+    Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver:
+        class: Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver
+
+    Bazinga\GeocoderBundle\Doctrine\ORM\GeocoderListener:
+        class: Bazinga\GeocoderBundle\Doctrine\ORM\GeocoderListener
+        arguments:
+            - '@bazinga_geocoder.provider.acme'
+            - '@Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver'
+        tags:
+            - doctrine.event_subscriber
+```

--- a/Tests/Mapping/Driver/AttributeDriverTest.php
+++ b/Tests/Mapping/Driver/AttributeDriverTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the BazingaGeocoderBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Bazinga\GeocoderBundle\Tests\Mapping\Driver;
+
+use Bazinga\GeocoderBundle\Mapping\Annotations\Geocodeable;
+use Bazinga\GeocoderBundle\Mapping\Annotations\Address;
+use Bazinga\GeocoderBundle\Mapping\Annotations\Latitude;
+use Bazinga\GeocoderBundle\Mapping\Annotations\Longitude;
+use Bazinga\GeocoderBundle\Mapping\Driver\AttributeDriver;
+use Bazinga\GeocoderBundle\Mapping\Exception\MappingException;
+use Doctrine\Common\Annotations\Reader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+
+/**
+ * @author Pierre du Plessis <pdples@gmail.com>
+ */
+class AttributeDriverTest extends TestCase
+{
+    use SetUpTearDownTrait;
+
+    /**
+     * @var AttributeDriver
+     */
+    private $driver;
+
+    /**
+     * @var Reader
+     */
+    private $reader;
+
+    protected function doSetUp(): void
+    {
+        $this->driver = new AttributeDriver();
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testLoadMetadata()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped(sprintf('"%s" is only supported on PHP 8', AttributeDriver::class));
+        }
+
+        $obj = new Dummy3();
+        $metadata = $this->driver->loadMetadataFromObject($obj);
+
+        $this->assertInstanceOf('ReflectionProperty', $metadata->addressProperty);
+        $this->assertInstanceOf('ReflectionProperty', $metadata->latitudeProperty);
+        $this->assertInstanceOf('ReflectionProperty', $metadata->longitudeProperty);
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testLoadMetadataFromWrongObject()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped(sprintf('"%s" is only supported on PHP 8', AttributeDriver::class));
+        }
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('The class '.Dummy4::class.' is not geocodeable');
+
+        $this->driver->loadMetadataFromObject(new Dummy4());
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testIsGeocodable()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped(sprintf('"%s" is only supported on PHP 8', AttributeDriver::class));
+        }
+
+        $this->assertTrue($this->driver->isGeocodeable(new Dummy3()));
+    }
+}
+
+#[Geocodeable()]
+class Dummy3
+{
+    #[Latitude()]
+    public $latitude;
+
+    #[Longitude()]
+    public $longitude;
+
+    #[Address()]
+    public $address;
+}
+
+class Dummy4
+{
+}


### PR DESCRIPTION
This fixes #277

There are a few different aspects to this PR:

* This includes the changes in #302
* Add support to define the provider per entity
	This is added with a new `provider` option on the `Geocodable` class, which can be used to define a different provider for each entity:

```php

#[Geocodable(povider: 'foo')]
class User {}

#[Geocodable(povider: 'bar')]
class DifferentUser {}
```

* This deprecates the `GeocoderListener` class in favor of a new `GeocodeEntityListener` class.
	The reason for this is so that we can auto-register the `GeocodeEntityListener` class when Doctrine is available, and automatically have a lookup for each provider. All the different providers are added to a service-locator, which is then used to look up the provider for an entity in the listener.
* Add a new `ChainDriver` for metadata, where all the different metadata drivers are added (`AttributeDriver` and `AnnotationDriver`)
	This allows to quickly switch between using annotations to using attributes without needing to make any config or service changes