### PR TITLE
Register Bundle / remove it

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -37,19 +37,6 @@ and then you may just install the bundle like normal:
 composer require willdurand/geocoder-bundle:^5.0
 ```
 
-Register the bundle in `app/AppKernel.php`:
-
-```php
-// app/AppKernel.php
-public function registerBundles()
-{
-    return array(
-        // ...
-        new Bazinga\GeocoderBundle\BazingaGeocoderBundle(),
-    );
-}
-```
-
 Usage
 -----
 


### PR DESCRIPTION
In from symfony4 are bundles  autowired. (i am only newbie) but i red documentation https://symfony.com/doc/3.3/bundles.html
As i see now.. from version 5.14 the Symfony 3.4 support was removed.. that i think... this part about registering bundle will confuse the less experienced users.
Or if you want let this text there.. i will suggest write there that is necessary only for Symfony 3