### PR TITLE
Allow fake IP works for all IPs

### DIFF
--- a/Plugin/FakeIpPlugin.php
+++ b/Plugin/FakeIpPlugin.php
@@ -76,6 +76,9 @@ class FakeIpPlugin implements Plugin
         if ($count > 0) {
             $query = $query->withText($text);
         }
+        if (null === $this->needle || '' === $this->needle) {
+            $query = $query->withText($replacement);
+        }
 
         return $next($query);
     }

--- a/Tests/Plugin/FakeIpPluginTest.php
+++ b/Tests/Plugin/FakeIpPluginTest.php
@@ -33,9 +33,13 @@ class FakeIpPluginTest extends TestCase
         $this->assertSame($query->getText(), '123.123.123.123');
     }
 
-    public function testEmptyLocalIpQuery()
+    /**
+     * @testWith [null]
+     *           ['']
+     */
+    public function testEmptyLocalIpQuery(?string $localIp)
     {
-        $fakeIpPlugin = new FakeIpPlugin('', '123.123.123.123');
+        $fakeIpPlugin = new FakeIpPlugin($localIp, '123.123.123.123');
         $query = GeocodeQuery::create('124.124.124.124');
 
         /** @var Query $query */
@@ -43,18 +47,6 @@ class FakeIpPluginTest extends TestCase
 
         $this->assertSame($query->getText(), '123.123.123.123');
     }
-
-    public function testNullLocalIpQuery()
-    {
-        $fakeIpPlugin = new FakeIpPlugin(null, '123.123.123.123');
-        $query = GeocodeQuery::create('124.124.124.124');
-
-        /** @var Query $query */
-        $query = $fakeIpPlugin->handleQuery($query, function (Query $query) { return $query; }, function () {});
-
-        $this->assertSame($query->getText(), '123.123.123.123');
-    }
-
     public function testHandleQueryUsingFaker()
     {
         $fakeIpPlugin = new FakeIpPlugin('127.0.0.1', '192.168.1.1', true);

--- a/Tests/Plugin/FakeIpPluginTest.php
+++ b/Tests/Plugin/FakeIpPluginTest.php
@@ -47,6 +47,7 @@ class FakeIpPluginTest extends TestCase
 
         $this->assertSame($query->getText(), '123.123.123.123');
     }
+
     public function testHandleQueryUsingFaker()
     {
         $fakeIpPlugin = new FakeIpPlugin('127.0.0.1', '192.168.1.1', true);

--- a/Tests/Plugin/FakeIpPluginTest.php
+++ b/Tests/Plugin/FakeIpPluginTest.php
@@ -33,6 +33,28 @@ class FakeIpPluginTest extends TestCase
         $this->assertSame($query->getText(), '123.123.123.123');
     }
 
+    public function testEmptyLocalIpQuery()
+    {
+        $fakeIpPlugin = new FakeIpPlugin('', '123.123.123.123');
+        $query = GeocodeQuery::create('124.124.124.124');
+
+        /** @var Query $query */
+        $query = $fakeIpPlugin->handleQuery($query, function (Query $query) { return $query; }, function () {});
+
+        $this->assertSame($query->getText(), '123.123.123.123');
+    }
+
+    public function testNullLocalIpQuery()
+    {
+        $fakeIpPlugin = new FakeIpPlugin(null, '123.123.123.123');
+        $query = GeocodeQuery::create('124.124.124.124');
+
+        /** @var Query $query */
+        $query = $fakeIpPlugin->handleQuery($query, function (Query $query) { return $query; }, function () {});
+
+        $this->assertSame($query->getText(), '123.123.123.123');
+    }
+
     public function testHandleQueryUsingFaker()
     {
         $fakeIpPlugin = new FakeIpPlugin('127.0.0.1', '192.168.1.1', true);


### PR DESCRIPTION
when local_ip is empty, allow to change all ip with fake one. usefull when we can't predict dev IP when using containers for example