### PR TITLE
Fix FakeIpPlugin

### DIFF
--- a/Plugin/FakeIpPlugin.php
+++ b/Plugin/FakeIpPlugin.php
@@ -26,7 +26,7 @@ use Geocoder\Query\Query;
 class FakeIpPlugin implements Plugin
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $needle;
 
@@ -36,20 +36,14 @@ class FakeIpPlugin implements Plugin
     private $replacement;
 
     /**
-     * @var bool
-     */
-    private $useFaker;
-
-    /**
      * @var Generator|null
      */
     private $faker;
 
-    public function __construct(string $needle, string $replacement = null, bool $useFaker = false)
+    public function __construct(?string $needle, string $replacement = null, bool $useFaker = false)
     {
         $this->needle = $needle;
         $this->replacement = $replacement;
-        $this->useFaker = $useFaker;
 
         if ($useFaker) {
             $this->faker = new Generator();
@@ -69,14 +63,16 @@ class FakeIpPlugin implements Plugin
         $replacement = $this->replacement;
 
         if (null !== $this->faker) {
-            $replacement = $this->faker->ipv4;
+            $replacement = $this->faker->ipv4();
         }
 
-        $text = str_replace($this->needle, $replacement, $query->getText(), $count);
-        if ($count > 0) {
-            $query = $query->withText($text);
-        }
-        if (null === $this->needle || '' === $this->needle) {
+        if (null !== $this->needle && '' !== $this->needle) {
+            $text = str_replace($this->needle, $replacement, $query->getText(), $count);
+
+            if ($count > 0) {
+                $query = $query->withText($text);
+            }
+        } else {
             $query = $query->withText($replacement);
         }
 

--- a/Tests/Plugin/FakeIpPluginTest.php
+++ b/Tests/Plugin/FakeIpPluginTest.php
@@ -35,7 +35,7 @@ class FakeIpPluginTest extends TestCase
 
     /**
      * @testWith [null]
-     *           ['']
+     *           [""]
      */
     public function testEmptyLocalIpQuery(?string $localIp)
     {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require-dev": {
     "doctrine/cache": "~1.3",
     "doctrine/orm": "~2.8",
-    "fakerphp/faker": "^1.9",
+    "fakerphp/faker": "^1.14",
     "friendsofphp/php-cs-fixer": "^3.0",
     "geocoder-php/algolia-places-provider": "^0.3",
     "geocoder-php/arcgis-online-provider": "^4.3",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,3 +12,6 @@ parameters:
 		-
 			path: %currentWorkingDirectory%/ProviderFactory/GeoipFactory.php
 			message: '#Geocoder\\Provider\\Geoip\\Geoip not found#'
+		-
+			path: %currentWorkingDirectory%/Plugin/FakeIpPlugin.php
+			message: '#Call to an undefined method Faker\\Generator::ipv4\(\)#'


### PR DESCRIPTION
- Allow needle to be null;
- Fix @testWith syntax error;
- Remove unnecessary `useFaker` variable;
- Handle `Since fakerphp/faker 1.14: Accessing property "ipv4" is deprecated, use "ipv4()" instead.` deprecation.