### PR TITLE
Fix deprecations with Symfony 6.1

### DIFF
--- a/Command/GeocodeCommand.php
+++ b/Command/GeocodeCommand.php
@@ -25,8 +25,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class GeocodeCommand extends Command
 {
-    protected static $defaultName = 'geocoder:geocode';
-
     /**
      * @var ProviderAggregator
      */

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -26,7 +26,8 @@ services:
 
     Bazinga\GeocoderBundle\Command\GeocodeCommand:
         arguments: ['@Geocoder\ProviderAggregator']
-        tags: ['console.command']
+        tags:
+            - { name: 'console.command', command: 'geocoder:geocode' }
 
     Bazinga\GeocoderBundle\Validator\Constraint\AddressValidator:
         arguments: ['@geocoder']

--- a/Tests/Functional/ProviderFactoryTest.php
+++ b/Tests/Functional/ProviderFactoryTest.php
@@ -93,7 +93,7 @@ class ProviderFactoryTest extends KernelTestCase
         yield [BingMaps::class, ['acme']];
         yield [Chain::class, ['acme']];
         yield [FreeGeoIp::class, ['empty', 'acme']];
-        //yield [Geoip::class, ['empty']];
+        // yield [Geoip::class, ['empty']];
         yield [GeoIP2::class, ['acme']];
         if (class_exists(GeoIPs::class)) {
             yield [GeoIPs::class, ['acme']];


### PR DESCRIPTION
This will keep [the command lazy loaded](https://symfony.com/doc/4.4/console/commands_as_services.html#lazy-loading) and prevents triggering deprecations when using [Symfony 6.1](https://github.com/symfony/symfony/blob/6.1/UPGRADE-6.1.md#console)