### PR TITLE
Allow using Symfony 7 and fix some deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
                       sf_version: '6.0.*'
                     - php: '8.2'
                       sf_version: '6.2.*'
+                    - php: '8.2'
+                      sf_version: '6.4.*'
+                    - php: '8.2'
+                      sf_version: '7.0.*'
         steps:
             - name: "Setup PHP"
               uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     "geocoder-php/plugin": "^1.5",
     "php-http/curl-client": "^2.3",
     "php-http/discovery": "^1.14",
-    "symfony/console": "^4.4 || ^5.0 || ^6.0",
-    "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
-    "symfony/options-resolver": "^4.4 || ^5.0 || ^6.0",
+    "symfony/console": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+    "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+    "symfony/options-resolver": "^4.4 || ^5.0 || ^6.0 || ^7.0",
     "willdurand/geocoder": "^4.6"
   },
   "require-dev": {
@@ -63,11 +63,11 @@
     "php-http/message": "^1.13",
     "phpstan/phpstan": "^1.9.2",
     "psr/http-client": "^1.0",
-    "symfony/cache": "^4.4 || ^5.0 || ^6.0",
-    "symfony/config": "^4.4 || ^5.0 || ^6.0",
-    "symfony/phpunit-bridge": "^5.2 || ^6.0",
-    "symfony/validator": "^4.4 || ^5.0 || ^6.0",
-    "symfony/yaml": "^4.4 || ^5.0 || ^6.0"
+    "symfony/cache": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+    "symfony/config": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+    "symfony/phpunit-bridge": "^5.2 || ^6.0 || ^7.0",
+    "symfony/validator": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+    "symfony/yaml": "^4.4 || ^5.0 || ^6.0 || ^7.0"
   },
   "conflict": {
     "geocoder-php/nominatim-provider": "<5.0"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -141,6 +141,11 @@ parameters:
 			path: src/Doctrine/ORM/GeocoderListener.php
 
 		-
+			message: "#^Method Bazinga\\\\GeocoderBundle\\\\Plugin\\\\FakeIpPlugin\\:\\:handleQuery\\(\\) return type with generic interface Http\\\\Promise\\\\Promise does not specify its types\\: T$#"
+			count: 1
+			path: src/Plugin/FakeIpPlugin.php
+
+		-
 			message: "#^Parameter \\#1 \\$text of method Geocoder\\\\Query\\\\GeocodeQuery\\:\\:withText\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Plugin/FakeIpPlugin.php
@@ -149,6 +154,11 @@ parameters:
 			message: "#^Parameter \\#2 \\$replace of function str_replace expects array\\|string, string\\|null given\\.$#"
 			count: 1
 			path: src/Plugin/FakeIpPlugin.php
+
+		-
+			message: "#^Method Bazinga\\\\GeocoderBundle\\\\Plugin\\\\ProfilingPlugin\\:\\:handleQuery\\(\\) return type with generic interface Http\\\\Promise\\\\Promise does not specify its types\\: T$#"
+			count: 1
+			path: src/Plugin/ProfilingPlugin.php
 
 		-
 			message: "#^Parameter \\#1 \\$accountId of class GeoIp2\\\\WebService\\\\Client constructor expects int, int\\|null given\\.$#"

--- a/src/Command/GeocodeCommand.php
+++ b/src/Command/GeocodeCommand.php
@@ -55,10 +55,7 @@ HELP
             );
     }
 
-    /**
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('provider')) {
             $this->geocoder->using($input->getOption('provider'));

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -30,10 +30,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Generates the configuration tree builder.
-     *
-     * @return TreeBuilder The tree builder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('bazinga_geocoder');
         $rootNode = $treeBuilder->getRootNode();


### PR DESCRIPTION
I'm updating some applications to Symfony 7 and one of them uses this bundle.

This PR adds `|| ^7.0` to the allowed Symfony dependencies and also adds the two return types that are mandatory in order to run the code in Symfony 7. I know there's #343 to add types everywhere, but these two small changes are enough to make the bundle work in Symfony 7.

Thanks!