### PR TITLE
fix: [profiler] don't use dump/profiler_dump for number of results

### DIFF
--- a/templates/Collector/geocoder.html.twig
+++ b/templates/Collector/geocoder.html.twig
@@ -99,7 +99,7 @@
                                 {% if query.result.message is defined %}
                                     Exception
                                 {% else %}
-                                    <span class="colored text-bold">{{ query.resultCount }}</span> Result(s)
+                                    <span class="sf-dump-num text-bold">{{ query.resultCount }}</span> Result(s)
                                 {% endif %}
                             </span>
                             <span class="metadata">

--- a/templates/Collector/geocoder.html.twig
+++ b/templates/Collector/geocoder.html.twig
@@ -99,7 +99,7 @@
                                 {% if query.result.message is defined %}
                                     Exception
                                 {% else %}
-                                    {{ profiler_dump(query.resultCount) }} Result(s)
+                                    <span class="colored text-bold">{{ query.resultCount }}</span> Result(s)
                                 {% endif %}
                             </span>
                             <span class="metadata">


### PR DESCRIPTION
Closes #361 

I'm not sure if there was some color before, as `dump` would show only `int(5)` with sf7 project.
This gets it highlighted.