### PR TITLE
Added configuration options for error levels

### DIFF
--- a/src/ProviderFactory/ChainFactory.php
+++ b/src/ProviderFactory/ChainFactory.php
@@ -30,7 +30,7 @@ final class ChainFactory extends AbstractFactory implements LoggerAwareInterface
     ];
 
     /**
-     * @param array{services: Provider[]} $config
+     * @param array{services: Provider[], geocode_log_level?: string|null, reverse_log_level?: string|null} $config
      */
     protected function getProvider(array $config): Provider
     {


### PR DESCRIPTION
The chain provider allows you to specify the error levels you want to use.

The current configuration is at the "ALERT" level, which is appropriate for some features, but for other environments the log load can be very costly.

By allowing these configuration options, projects that want to use this provider can adjust this logging level to their needs.