### PR TITLE
Replace deprecated `HttpClientDiscovery` usage to `Psr18ClientDiscovery`

### DIFF
--- a/src/ProviderFactory/AlgoliaFactory.php
+++ b/src/ProviderFactory/AlgoliaFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\AlgoliaPlaces\AlgoliaPlaces;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class AlgoliaFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new AlgoliaPlaces($httpClient, $config['api_key'], $config['app_id']);
     }

--- a/src/ProviderFactory/ArcGISOnlineFactory.php
+++ b/src/ProviderFactory/ArcGISOnlineFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\ArcGISOnline\ArcGISOnline;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class ArcGISOnlineFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new ArcGISOnline($httpClient, $config['source_country']);
     }

--- a/src/ProviderFactory/BingMapsFactory.php
+++ b/src/ProviderFactory/BingMapsFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\BingMaps\BingMaps;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class BingMapsFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new BingMaps($httpClient, $config['api_key']);
     }

--- a/src/ProviderFactory/FreeGeoIpFactory.php
+++ b/src/ProviderFactory/FreeGeoIpFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\FreeGeoIp\FreeGeoIp;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class FreeGeoIpFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new FreeGeoIp($httpClient, $config['base_url']);
     }

--- a/src/ProviderFactory/GeoPluginFactory.php
+++ b/src/ProviderFactory/GeoPluginFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\GeoPlugin\GeoPlugin;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class GeoPluginFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new GeoPlugin($httpClient);
     }

--- a/src/ProviderFactory/GeonamesFactory.php
+++ b/src/ProviderFactory/GeonamesFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\Geonames\Geonames;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class GeonamesFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new Geonames($httpClient, $config['username']);
     }

--- a/src/ProviderFactory/GoogleMapsFactory.php
+++ b/src/ProviderFactory/GoogleMapsFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\GoogleMaps\GoogleMaps;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class GoogleMapsFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new GoogleMaps($httpClient, $config['region'], $config['api_key']);
     }

--- a/src/ProviderFactory/GoogleMapsPlacesFactory.php
+++ b/src/ProviderFactory/GoogleMapsPlacesFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\GoogleMapsPlaces\GoogleMapsPlaces;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class GoogleMapsPlacesFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new GoogleMapsPlaces($httpClient, $config['api_key']);
     }

--- a/src/ProviderFactory/HereFactory.php
+++ b/src/ProviderFactory/HereFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\Here\Here;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -33,7 +33,7 @@ final class HereFactory extends AbstractFactory
             throw new \InvalidArgumentException('No authentication key provided. Here requires app_key or app_code and app_id.');
         }
 
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         if (!empty($config['app_key'])) {
             if (!method_exists(Here::class, 'createUsingApiKey')) {

--- a/src/ProviderFactory/HostIpFactory.php
+++ b/src/ProviderFactory/HostIpFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\HostIp\HostIp;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class HostIpFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new HostIp($httpClient);
     }

--- a/src/ProviderFactory/IpInfoDbFactory.php
+++ b/src/ProviderFactory/IpInfoDbFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\IpInfoDb\IpInfoDb;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class IpInfoDbFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new IpInfoDb($httpClient, $config['api_key'], $config['precision']);
     }

--- a/src/ProviderFactory/IpInfoFactory.php
+++ b/src/ProviderFactory/IpInfoFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\IpInfo\IpInfo;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class IpInfoFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new IpInfo($httpClient);
     }

--- a/src/ProviderFactory/IpstackFactory.php
+++ b/src/ProviderFactory/IpstackFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\Ipstack\Ipstack;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class IpstackFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new Ipstack($httpClient, $config['api_key']);
     }

--- a/src/ProviderFactory/LocationIQFactory.php
+++ b/src/ProviderFactory/LocationIQFactory.php
@@ -12,7 +12,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\LocationIQ\LocationIQ;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -27,7 +27,7 @@ final class LocationIQFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new LocationIQ($httpClient, $config['api_key']);
     }

--- a/src/ProviderFactory/MapQuestFactory.php
+++ b/src/ProviderFactory/MapQuestFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\MapQuest\MapQuest;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class MapQuestFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new MapQuest($httpClient, $config['api_key'], $config['licensed']);
     }

--- a/src/ProviderFactory/MapboxFactory.php
+++ b/src/ProviderFactory/MapboxFactory.php
@@ -12,7 +12,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\Mapbox\Mapbox;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -27,7 +27,7 @@ final class MapboxFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new Mapbox($httpClient, $config['api_key'], $config['country'], $config['mode']);
     }

--- a/src/ProviderFactory/MaxMindFactory.php
+++ b/src/ProviderFactory/MaxMindFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\MaxMind\MaxMind;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class MaxMindFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new MaxMind($httpClient, $config['api_key'], $config['endpoint']);
     }

--- a/src/ProviderFactory/NominatimFactory.php
+++ b/src/ProviderFactory/NominatimFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\Nominatim\Nominatim;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class NominatimFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new Nominatim($httpClient, $config['root_url'], $config['user_agent']);
     }

--- a/src/ProviderFactory/OpenCageFactory.php
+++ b/src/ProviderFactory/OpenCageFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\OpenCage\OpenCage;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class OpenCageFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new OpenCage($httpClient, $config['api_key']);
     }

--- a/src/ProviderFactory/OpenRouteServiceFactory.php
+++ b/src/ProviderFactory/OpenRouteServiceFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\OpenRouteService\OpenRouteService;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class OpenRouteServiceFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new OpenRouteService($httpClient, $config['api_key']);
     }

--- a/src/ProviderFactory/PickPointFactory.php
+++ b/src/ProviderFactory/PickPointFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\PickPoint\PickPoint;
 use Geocoder\Provider\Provider;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class PickPointFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new PickPoint($httpClient, $config['api_key']);
     }

--- a/src/ProviderFactory/TomTomFactory.php
+++ b/src/ProviderFactory/TomTomFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\Provider;
 use Geocoder\Provider\TomTom\TomTom;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class TomTomFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new TomTom($httpClient, $config['api_key']);
     }

--- a/src/ProviderFactory/YandexFactory.php
+++ b/src/ProviderFactory/YandexFactory.php
@@ -14,7 +14,7 @@ namespace Bazinga\GeocoderBundle\ProviderFactory;
 
 use Geocoder\Provider\Provider;
 use Geocoder\Provider\Yandex\Yandex;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ final class YandexFactory extends AbstractFactory
      */
     protected function getProvider(array $config): Provider
     {
-        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? HttpClientDiscovery::find();
+        $httpClient = $config['http_client'] ?? $config['httplug_client'] ?? $this->httpClient ?? Psr18ClientDiscovery::find();
 
         return new Yandex($httpClient, $config['toponym'], $config['api_key']);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated HTTP client discovery mechanism across all provider factories to use PSR-18 compliant client resolution, improving compatibility and standardization while maintaining backward compatibility with no changes to public APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->