### PR TITLE
Remove deprecated `Address::$errorNames`

### DIFF
--- a/src/Validator/Constraint/Address.php
+++ b/src/Validator/Constraint/Address.php
@@ -30,13 +30,6 @@ class Address extends Constraint
     ];
 
     /**
-     * @var array<string, string>
-     *
-     * @deprecated since BazingaGeocoderBundle 5.17, use const ERROR_NAMES instead
-     */
-    protected static $errorNames = self::ERROR_NAMES;
-
-    /**
      * @var string
      */
     public $service = AddressValidator::class;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated code from the validation component to improve code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->