### PR TITLE
ci: fix deprecation for PhpCsFixer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           composer-options: "--optimize-autoloader"
 
       - name: "Run PHP-CS-Fixer"
-        run: vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no --format=checkstyle | cs2pr
+        run: vendor/bin/php-cs-fixer fix -v --dry-run --allow-unsupported-php-version=yes --using-cache=no --format=checkstyle | cs2pr
 
   phpunit:
     name: PHPUnit (PHP ${{ matrix.php }}) (Symfony ${{ matrix.sf_version }})

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -10,7 +10,6 @@ return (new PhpCsFixer\Config())
         '@Symfony' => true,
         'no_superfluous_phpdoc_tags' => false,
         'phpdoc_to_comment' => ['ignored_tags' => ['var']], // phpstan errors pops up without this
-        'unsupportedPhpVersionAllowed' => true,
     ])
     ->setFinder($finder)
 ;


### PR DESCRIPTION
```Setting PHP_CS_FIXER_IGNORE_ENV environment variable is deprecated and will be removed in 4.0, use unsupportedPhpVersionAllowed config instead.```

https://cs.symfony.com/doc/usage.html#environment