### PR TITLE
Allow stringable object to be used to geocode address

### DIFF
--- a/src/Doctrine/ORM/GeocoderListener.php
+++ b/src/Doctrine/ORM/GeocoderListener.php
@@ -57,7 +57,7 @@ class GeocoderListener implements EventSubscriber
             $this->geocodeEntity($metadata, $entity);
 
             $uow->recomputeSingleEntityChangeSet(
-                $em->getClassMetadata(get_class($entity)),
+                $em->getClassMetadata($entity::class),
                 $entity
             );
         }
@@ -76,7 +76,7 @@ class GeocoderListener implements EventSubscriber
             $this->geocodeEntity($metadata, $entity);
 
             $uow->recomputeSingleEntityChangeSet(
-                $em->getClassMetadata(get_class($entity)),
+                $em->getClassMetadata($entity::class),
                 $entity
             );
         }
@@ -92,11 +92,16 @@ class GeocoderListener implements EventSubscriber
             $address = '';
         }
 
-        if (empty($address) || !is_string($address)) {
+        if (!is_string($address) && !$address instanceof \Stringable) {
             return;
         }
 
-        $results = $this->geocoder->geocodeQuery(GeocodeQuery::create($address));
+        $addressString = (string) $address;
+        if ('' === $addressString) {
+            return;
+        }
+
+        $results = $this->geocoder->geocodeQuery(GeocodeQuery::create($addressString));
 
         if (!$results->isEmpty()) {
             $result = $results->first();

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -40,7 +40,7 @@ final class AttributeDriver implements DriverInterface
         $attributes = $reflection->getAttributes(Attributes\Geocodeable::class);
 
         if ([] === $attributes) {
-            throw new MappingException(sprintf('The class "%s" is not geocodeable', get_class($object)));
+            throw new MappingException(sprintf('The class "%s" is not geocodeable', $object::class));
         }
 
         $args = [];

--- a/tests/Functional/Fixtures/Entity/DummyWithStringableGetter.php
+++ b/tests/Functional/Fixtures/Entity/DummyWithStringableGetter.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the BazingaGeocoderBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Bazinga\GeocoderBundle\Tests\Functional\Fixtures\Entity;
+
+use Bazinga\GeocoderBundle\Mapping\Attributes\Address;
+use Bazinga\GeocoderBundle\Mapping\Attributes\Geocodeable;
+use Bazinga\GeocoderBundle\Mapping\Attributes\Latitude;
+use Bazinga\GeocoderBundle\Mapping\Attributes\Longitude;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embedded;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+
+#[Entity]
+#[Geocodeable]
+final class DummyWithStringableGetter
+{
+    #[Id]
+    #[GeneratedValue]
+    #[Column(type: Types::INTEGER)]
+    public $id;
+
+    #[Column]
+    #[Latitude]
+    public $latitude;
+
+    #[Column]
+    #[Longitude]
+    public $longitude;
+
+    #[Embedded]
+    public StringableAddress $address;
+
+    public function setAddress(StringableAddress $address): void
+    {
+        $this->address = $address;
+    }
+
+    #[Address]
+    public function getAddress(): StringableAddress
+    {
+        return $this->address;
+    }
+}

--- a/tests/Functional/Fixtures/Entity/StringableAddress.php
+++ b/tests/Functional/Fixtures/Entity/StringableAddress.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the BazingaGeocoderBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Bazinga\GeocoderBundle\Tests\Functional\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
+
+#[Embeddable]
+final class StringableAddress implements \Stringable
+{
+    public function __construct(
+        #[Column]
+        private string $address,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->address;
+    }
+}


### PR DESCRIPTION
Closes #351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Stringable address objects in geocoding; stringable addresses are accepted and normalized to strings before geocoding.

* **Bug Fixes**
  * Improved handling of address values: non-stringable or empty addresses are skipped to avoid spurious geocode attempts.
  * Error messages now report class names more consistently.

* **Tests**
  * Added functional tests and fixtures covering stringable-address entities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->