### PR TITLE
feat: drop support for symfony < 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     "php": "^8.1",
     "geocoder-php/plugin": "^1.5",
     "php-http/discovery": "^1.14",
-    "symfony/console": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-    "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-    "symfony/options-resolver": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+    "symfony/console": "^6.4 || ^7.0 || ^8.0",
+    "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+    "symfony/options-resolver": "^6.4 || ^7.0 || ^8.0",
     "willdurand/geocoder": "^4.6|^5.0"
   },
   "require-dev": {
@@ -55,17 +55,17 @@
     "geocoder-php/yandex-provider": "^4.6",
     "nyholm/nsa": "^1.3",
     "nyholm/psr7": "^1.8",
-    "nyholm/symfony-bundle-test": "^2.0 || ^3.0",
+    "nyholm/symfony-bundle-test": "^3.1",
     "phpstan/phpstan": "^1.9.2",
     "psr/http-client": "^1.0",
     "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-    "symfony/cache": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-    "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-    "symfony/http-client": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-    "symfony/phpunit-bridge": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-    "symfony/validator": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-    "symfony/var-exporter": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-    "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || ^8.0"
+    "symfony/cache": "^6.4 || ^7.0 || ^8.0",
+    "symfony/config": "^6.4 || ^7.0 || ^8.0",
+    "symfony/http-client": "^6.4 || ^7.0 || ^8.0",
+    "symfony/phpunit-bridge": "^6.4 || ^7.0 || ^8.0",
+    "symfony/validator": "^6.4 || ^7.0 || ^8.0",
+    "symfony/var-exporter": "^6.4 || ^7.0 || ^8.0",
+    "symfony/yaml": "^6.4 || ^7.0 || ^8.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
i just noticed that it was already removed from the ci.

`nyholm/symfony-bundle-test` could be bumped to 3.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version constraints to require modern versions of core dependencies.
  * Removed support for older dependency versions, ensuring compatibility with current releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->