### PR TITLE
fix: add symfony/validator as required dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "symfony/console": "^6.4 || ^7.0 || ^8.0",
     "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
     "symfony/options-resolver": "^6.4 || ^7.0 || ^8.0",
+    "symfony/validator": "^6.4 || ^7.0 || ^8.0",
     "willdurand/geocoder": "^4.6|^5.0"
   },
   "require-dev": {
@@ -63,7 +64,6 @@
     "symfony/config": "^6.4 || ^7.0 || ^8.0",
     "symfony/http-client": "^6.4 || ^7.0 || ^8.0",
     "symfony/phpunit-bridge": "^6.4 || ^7.0 || ^8.0",
-    "symfony/validator": "^6.4 || ^7.0 || ^8.0",
     "symfony/var-exporter": "^6.4 || ^7.0 || ^8.0",
     "symfony/yaml": "^6.4 || ^7.0 || ^8.0"
   },


### PR DESCRIPTION
fixes https://github.com/geocoder-php/BazingaGeocoderBundle/issues/398
